### PR TITLE
refactor: eliminate LinterRule trait, unify all rules under WalkerRule

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,9 +25,10 @@ The heart of the suite. It encapsulates all domain logic, file parsing, rule enf
   - `Workbook` trait defines the common interface for all formats.
 
 - **`rules`**: Implements the linting logic.
-  - Each rule is a standalone struct implementing the `Rule` trait.
+  - Each rule is a standalone struct implementing the `WalkerRule` trait.
+  - The `WorkbookWalker` executes all rules in a single pass over the workbook.
   - Rules are registered in a central `Registry`.
-  - Categories: `ERR` (Errors), `SEC` (Security), `PERF` (Performance), `UX` (Usability), `SM` (Structure/Maintainability), `FORM` (Formula).
+  - Categories: `ERR` (Errors), `CALC` (Calculations), `REF` (References), `INT` (Interruptions), `CPX` (Complexity), `VUL` (Vulnerability), `DATA` (Data Issues), `EXT` (External), `HID` (Hidden), `FILE` (Files), `VBA` (Macros).
 
 - **`config`**: Handles TOML configuration.
   - Hierarchical loading: Default -> Global Config -> Sheet Overrides.

--- a/changelog.d/walker-migration.removed.md
+++ b/changelog.d/walker-migration.removed.md
@@ -1,0 +1,1 @@
+Eliminate `LinterRule` trait: migrate all 17 remaining rules to unified `WalkerRule` single-pass architecture.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ getting-started instructions, see the root [README.md](../README.md).
   design principles (format-agnostic rules, streaming readers, rayon
   parallelism).
 - [Coding Patterns](coding-patterns.md) — conventions, naming, SoC principle,
-  Rule/Walker trait patterns, CLI and library guidelines.
+  WalkerRule trait pattern, CLI and library guidelines.
 
 ## Analysis & Profiling
 

--- a/docs/coding-patterns.md
+++ b/docs/coding-patterns.md
@@ -30,23 +30,26 @@ failure. Silent misconfiguration is not acceptable.
 
 ### The Rule Trait
 
-Each rule is a standalone struct implementing the `Rule` trait. Rules are
+Each rule is a standalone struct implementing the `WalkerRule` trait. Rules are
 registered in a central `Registry`.
 
-Categories: `ERR` (Errors), `SEC` (Security), `PERF` (Performance),
-`UX` (Usability), `SM` (Structure/Maintainability), `FORM` (Formula).
+Categories: `ERR` (Errors), `CALC` (Calculations), `REF` (References),
+`INT` (Interruptions), `CPX` (Complexity), `VUL` (Vulnerability),
+`DATA` (Data Issues), `EXT` (External), `HID` (Hidden), `FILE` (Files),
+`VBA` (Macros).
 
 ### The Walker Pattern
 
-Walker rules implement the `WalkerRule` trait for cell-by-cell traversal:
+All rules implement the `WalkerRule` trait, which provides lifecycle hooks
+for single-pass cell-by-cell traversal:
 
+- `on_workbook_start()` — called once before traversal begins.
+- `on_sheet_start()` — called at the start of each sheet.
 - `on_cell()` — called for each cell during the walk. Collect data into
   `LinterContext`.
+- `on_sheet_end()` — called at the end of each sheet.
 - `on_workbook_end()` — called after all cells are visited. Emit violations
   based on collected data.
-
-Use walkers when a rule needs cross-cell or cross-sheet analysis (e.g.,
-circular references, dependency graphs).
 
 ### Hierarchical Violations
 
@@ -92,7 +95,7 @@ The workspace uses [semantic versioning](https://semver.org/):
 The `sheetrs` library crate exports:
 
 - `reader` module — `Workbook` trait, format parsers
-- `rules` module — rule registry, `Rule` and `WalkerRule` traits
+- `rules` module — rule registry and `WalkerRule` trait
 - `config` module — TOML configuration loading
 - `writer` module — workbook modification utilities
 - `violation` module — violation types and formatting

--- a/sheetrs-wasm/src/lib.rs
+++ b/sheetrs-wasm/src/lib.rs
@@ -62,10 +62,10 @@ pub fn lint_workbook(
         .map_err(|e| JsValue::from_str(&format!("Linter error: {}", e)))?;
 
     // Create a map of rule_id -> rule_name for better output
-    let rules = registry::create_all_rules(&config);
-    let rule_names: HashMap<String, String> = rules
+    let metadata = registry::get_all_rule_metadata(&config);
+    let rule_names: HashMap<String, String> = metadata
         .iter()
-        .map(|r| (r.id().to_string(), r.name().to_string()))
+        .map(|m| (m.id.to_string(), m.name.clone()))
         .collect();
 
     Ok(format_violations_human(&violations, &rule_names, &workbook))

--- a/sheetrs/src/lib.rs
+++ b/sheetrs/src/lib.rs
@@ -13,7 +13,6 @@ use anyhow::Result;
 use std::path::Path;
 
 pub use config::LinterConfig;
-pub use rules::LinterRule;
 pub use violation::{FormatContext, RuleId, Severity, Violation, ViolationData, ViolationScope};
 
 use rules::WalkerRule;
@@ -22,7 +21,6 @@ use rules::walker::WorkbookWalker;
 /// Main linter interface
 pub struct Linter {
     config: LinterConfig,
-    rules: Vec<Box<dyn LinterRule>>,
     walker_rules: Vec<Box<dyn WalkerRule>>,
 }
 
@@ -34,11 +32,9 @@ impl Linter {
 
     /// Create a new linter with custom configuration
     pub fn with_config(config: LinterConfig) -> Self {
-        let rules = rules::registry::create_enabled_rules(&config);
         let walker_rules = rules::registry::create_enabled_walker_rules(&config);
         Self {
             config,
-            rules,
             walker_rules,
         }
     }
@@ -89,28 +85,6 @@ impl Linter {
             };
             if enabled {
                 violations.push(violation);
-            }
-        }
-
-        // Run legacy LinterRule checks
-        for rule in &self.rules {
-            let rule_violations = rule.check(workbook)?;
-
-            for violation in rule_violations {
-                let enabled = if let Some(sheet_idx) = violation.scope.sheet_index() {
-                    if let Some(sheet_name) = workbook.sheet_name_by_index(sheet_idx) {
-                        self.config
-                            .is_rule_enabled_for_sheet(violation.rule_id.as_str(), sheet_name)
-                    } else {
-                        true
-                    }
-                } else {
-                    true
-                };
-
-                if enabled {
-                    violations.push(violation);
-                }
             }
         }
 

--- a/sheetrs/src/rules/calc202_circular_references.rs
+++ b/sheetrs/src/rules/calc202_circular_references.rs
@@ -2,12 +2,11 @@
 //!
 //! Description: Detects recursive dependency loops that prevent successful calculation.
 
-use super::{LinterContext, LinterRule, RuleCategory, WalkerRule};
+use super::{LinterContext, RuleCategory, WalkerRule};
 use crate::reader::{Cell, Sheet, Workbook};
 use crate::violation::{
     CellReference, FormatContext, RuleId, Severity, Violation, ViolationData, ViolationScope,
 };
-use anyhow::Result;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 
@@ -81,96 +80,6 @@ impl ViolationData for CircularReferenceData {
     }
 }
 
-impl LinterRule for CircularReferenceRule {
-    fn id(&self) -> RuleId {
-        RuleId::Calc202
-    }
-
-    fn name(&self) -> &str {
-        "Circular Reference"
-    }
-
-    fn category(&self) -> RuleCategory {
-        RuleCategory::Calculations
-    }
-
-    fn check(&self, workbook: &Workbook) -> Result<Vec<Violation>> {
-        let mut violations = Vec::new();
-        // Build a name-to-index map for quick lookup
-        let name_to_index: HashMap<&str, u16> = workbook
-            .sheets
-            .iter()
-            .map(|s| (s.name.as_str(), s.sheet_index))
-            .collect();
-
-        // Global dependency graph: (SheetIndex, Row, Col) -> Vec<(SheetIndex, Row, Col)>
-        // Type alias to avoid clippy::type_complexity warning
-        type CellDependencyMap = HashMap<(u16, u32, u32), Vec<(u16, u32, u32)>>;
-        let mut dependencies: CellDependencyMap = HashMap::new();
-
-        // 1. Build the global dependency graph
-        for sheet in &workbook.sheets {
-            for cell in sheet.all_cells() {
-                if let Some(formula) = cell.as_formula() {
-                    let refs = extract_cell_references(
-                        formula,
-                        &self.cell_ref_pattern,
-                        sheet.sheet_index,
-                        &name_to_index,
-                    );
-                    dependencies.insert((sheet.sheet_index, cell.row, cell.col), refs);
-                }
-            }
-        }
-
-        // 2. Detect circular references using DFS on the global graph
-        let cycles = find_cycles(&dependencies);
-
-        // Build index-to-name map for violation messages
-        let index_to_name: HashMap<u16, &str> = workbook
-            .sheets
-            .iter()
-            .map(|s| (s.sheet_index, s.name.as_str()))
-            .collect();
-
-        let mut reported_cells = HashSet::new();
-
-        for cycle in cycles {
-            let is_duplicate = cycle.iter().any(|c| reported_cells.contains(c));
-
-            if !is_duplicate {
-                for cell in &cycle {
-                    reported_cells.insert(*cell);
-                }
-
-                // Format the cycle path including sheet names
-                let path_str: Vec<String> = cycle
-                    .iter()
-                    .map(|(idx, r, c)| {
-                        let sheet_name = index_to_name.get(idx).copied().unwrap_or("Unknown");
-                        format!("{}!{}", sheet_name, CellReference::new(*r, *c))
-                    })
-                    .collect();
-
-                let full_path = format!("{} -> {}", path_str.join(" -> "), path_str[0]);
-
-                // Report on the first cell
-                let (sheet_index, r, c) = &cycle[0];
-                let cell_ref = CellReference::new(*r, *c);
-
-                violations.push(Violation::new(
-                    RuleId::Calc202,
-                    ViolationScope::Cell(*sheet_index, cell_ref),
-                    format!("Circular reference detected: {}", full_path),
-                    Severity::Error,
-                ));
-            }
-        }
-
-        Ok(violations)
-    }
-}
-
 impl WalkerRule for CircularReferenceRule {
     fn id(&self) -> RuleId {
         RuleId::Calc202
@@ -186,7 +95,7 @@ impl WalkerRule for CircularReferenceRule {
 
     fn on_cell(&self, sheet: &Sheet, cell: &Cell, ctx: &mut LinterContext) -> Vec<Violation> {
         if let Some(formula) = cell.as_formula() {
-            let refs = extract_cell_references_walker(
+            let refs = extract_cell_references(
                 formula,
                 &self.cell_ref_pattern,
                 sheet.sheet_index,
@@ -239,8 +148,12 @@ impl WalkerRule for CircularReferenceRule {
     }
 }
 
-/// Extract cell references for walker rules (uses HashMap<String, u16>)
-fn extract_cell_references_walker(
+/// Extract cell references from a formula, resolving sheet names to indices.
+///
+/// Range references are represented by their corner cells (start and end) to prevent
+/// excessive memory usage with large spreadsheets. External workbook references are
+/// skipped since they cannot cause circular references within the current workbook.
+fn extract_cell_references(
     formula: &str,
     pattern: &Regex,
     current_sheet_index: u16,
@@ -286,76 +199,6 @@ fn extract_cell_references_walker(
                     references.push((sheet_index, end_row, end_col));
                 }
             } else {
-                references.push((sheet_index, start_row, start_col));
-            }
-        }
-    }
-
-    references
-}
-
-/// Extract cell references from a formula, resolving sheet names to indices.
-///
-/// Range references are represented by their corner cells (start and end) to prevent
-/// excessive memory usage with large spreadsheets. External workbook references are
-/// skipped since they cannot cause circular references within the current workbook.
-fn extract_cell_references(
-    formula: &str,
-    pattern: &Regex,
-    current_sheet_index: u16,
-    name_to_index: &HashMap<&str, u16>,
-) -> Vec<(u16, u32, u32)> {
-    let mut references = Vec::new();
-
-    for cap in pattern.captures_iter(formula) {
-        // Determine sheet index
-        // Group 1: Sheet name wrapper
-        // Group 2: Quoted content
-        // Group 3: Unquoted content
-        let sheet_index = if cap.get(1).is_some() {
-            if let Some(quoted) = cap.get(2) {
-                match name_to_index.get(quoted.as_str()).copied() {
-                    Some(idx) => idx,
-                    None => continue, // Skip external workbook references
-                }
-            } else if let Some(unquoted) = cap.get(3) {
-                match name_to_index.get(unquoted.as_str()).copied() {
-                    Some(idx) => idx,
-                    None => continue, // Skip external workbook references
-                }
-            } else {
-                // Fallback (shouldn't happen with valid regex)
-                current_sheet_index
-            }
-        } else {
-            current_sheet_index
-        };
-
-        // Group 4: Start Col (Alpha)
-        // Group 5: Start Row (Numeric)
-        if let (Some(col_match), Some(row_match)) = (cap.get(4), cap.get(5)) {
-            let col_str = col_match.as_str();
-            let row_str = row_match.as_str();
-
-            let (start_row, start_col) = match parse_components(row_str, col_str) {
-                Some(coords) => coords,
-                None => continue,
-            };
-
-            // Check for range end
-            // Group 6: End Col
-            // Group 7: End Row
-            if let (Some(end_col_match), Some(end_row_match)) = (cap.get(6), cap.get(7)) {
-                let end_col_str = end_col_match.as_str();
-                let end_row_str = end_row_match.as_str();
-
-                if let Some((end_row, end_col)) = parse_components(end_row_str, end_col_str) {
-                    // Only track corner cells to prevent memory issues
-                    references.push((sheet_index, start_row, start_col));
-                    references.push((sheet_index, end_row, end_col));
-                }
-            } else {
-                // Single cell reference
                 references.push((sheet_index, start_row, start_col));
             }
         }
@@ -466,6 +309,7 @@ fn find_cycles(dependencies: &HashMap<Node, Vec<Node>>) -> Vec<Vec<Node>> {
 mod tests {
     use super::*;
     use crate::reader::workbook::{Cell, CellValue, Sheet};
+    use crate::rules::walker::WorkbookWalker;
     use std::collections::HashMap;
     use std::path::PathBuf;
 
@@ -485,6 +329,13 @@ mod tests {
         }
     }
 
+    fn run_rule(workbook: &Workbook) -> Vec<Violation> {
+        let rule = CircularReferenceRule::new();
+        let rules: Vec<Box<dyn WalkerRule>> = vec![Box::new(rule)];
+        let walker = WorkbookWalker::new(workbook, rules);
+        walker.walk()
+    }
+
     #[test]
     fn test_circular_reference_direct() {
         let mut cells = HashMap::new();
@@ -501,8 +352,7 @@ mod tests {
         );
 
         let workbook = create_test_workbook("Sheet1", cells);
-        let rule = CircularReferenceRule::new();
-        let violations = rule.check(&workbook).unwrap();
+        let violations = run_rule(&workbook);
 
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].rule_id, RuleId::Calc202);
@@ -534,8 +384,7 @@ mod tests {
         );
 
         let workbook = create_test_workbook("Sheet1", cells);
-        let rule = CircularReferenceRule::new();
-        let violations = rule.check(&workbook).unwrap();
+        let violations = run_rule(&workbook);
 
         assert!(!violations.is_empty());
     }
@@ -569,8 +418,7 @@ mod tests {
         );
 
         let workbook = create_test_workbook("Sheet1", cells);
-        let rule = CircularReferenceRule::new();
-        let violations = rule.check(&workbook).unwrap();
+        let violations = run_rule(&workbook);
 
         // Should NOT detect cycle with non-expanding mode
         assert_eq!(violations.len(), 0);
@@ -603,8 +451,7 @@ mod tests {
         );
 
         let workbook = create_test_workbook("Sheet1", cells);
-        let rule = CircularReferenceRule::new();
-        let violations = rule.check(&workbook).unwrap();
+        let violations = run_rule(&workbook);
 
         // Cycle: A1 -> A3 -> A1
         assert_eq!(violations.len(), 1);

--- a/sheetrs/src/rules/calc203_double_operator.rs
+++ b/sheetrs/src/rules/calc203_double_operator.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Flags redundant operator sequences (e.g., "++", "--") indicating potential typos.
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies double operators in formulas
 pub struct DoubleOperatorRule;
 
-impl LinterRule for DoubleOperatorRule {
+impl WalkerRule for DoubleOperatorRule {
     fn id(&self) -> RuleId {
         RuleId::Calc203
     }
@@ -21,10 +19,5 @@ impl LinterRule for DoubleOperatorRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Calculations
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/calc204_approximate_lookup.rs
+++ b/sheetrs/src/rules/calc204_approximate_lookup.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Identifies lookup functions (e.g., VLOOKUP) missing the strict exact-match flag.
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies approximate lookup functions
 pub struct ApproximateLookupRule;
 
-impl LinterRule for ApproximateLookupRule {
+impl WalkerRule for ApproximateLookupRule {
     fn id(&self) -> RuleId {
         RuleId::Calc204
     }
@@ -21,10 +19,5 @@ impl LinterRule for ApproximateLookupRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Calculations
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/calc205_double_count.rs
+++ b/sheetrs/src/rules/calc205_double_count.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Flags redundant inclusion of specific cells in a summation logic.
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies double count issues in formulas
 pub struct DoubleCountRule;
 
-impl LinterRule for DoubleCountRule {
+impl WalkerRule for DoubleCountRule {
     fn id(&self) -> RuleId {
         RuleId::Calc205
     }
@@ -21,10 +19,5 @@ impl LinterRule for DoubleCountRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Calculations
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/cpx501_sheet_counts.rs
+++ b/sheetrs/src/rules/cpx501_sheet_counts.rs
@@ -2,11 +2,10 @@
 //!
 //! Description: Checks if the workbook has an excessive number of sheets, which complicates navigation.
 
-use super::{LinterContext, LinterRule, RuleCategory, WalkerRule};
+use super::{LinterContext, RuleCategory, WalkerRule};
 use crate::config::LinterConfig;
 use crate::reader::Workbook;
 use crate::violation::{FormatContext, RuleId, Severity, Violation, ViolationData, ViolationScope};
-use anyhow::Result;
 
 /// Rule that checks if the workbook has an excessive number of sheets.
 pub struct ExcessiveSheetCountsRule {
@@ -46,39 +45,6 @@ impl Default for ExcessiveSheetCountsRule {
     }
 }
 
-impl LinterRule for ExcessiveSheetCountsRule {
-    fn id(&self) -> RuleId {
-        RuleId::Cpx501
-    }
-
-    fn name(&self) -> &str {
-        "Sheet Counts"
-    }
-
-    fn category(&self) -> RuleCategory {
-        RuleCategory::Complexity
-    }
-
-    fn check(&self, workbook: &Workbook) -> Result<Vec<Violation>> {
-        let mut violations = Vec::new();
-        let sheet_count = workbook.sheets.len() as u32;
-
-        if sheet_count > self.threshold {
-            violations.push(Violation::new(
-                RuleId::Cpx501,
-                ViolationScope::Book,
-                format!(
-                    "Workbook has {} sheets (threshold: {})",
-                    sheet_count, self.threshold
-                ),
-                Severity::Warning,
-            ));
-        }
-
-        Ok(violations)
-    }
-}
-
 impl WalkerRule for ExcessiveSheetCountsRule {
     fn id(&self) -> RuleId {
         RuleId::Cpx501
@@ -113,6 +79,7 @@ impl WalkerRule for ExcessiveSheetCountsRule {
 mod tests {
     use super::*;
     use crate::reader::workbook::Sheet;
+    use crate::rules::walker::WorkbookWalker;
     use std::collections::HashMap;
     use std::path::PathBuf;
 
@@ -143,7 +110,9 @@ mod tests {
         };
 
         let rule = ExcessiveSheetCountsRule::default();
-        let violations = rule.check(&workbook).unwrap();
+        let rules: Vec<Box<dyn WalkerRule>> = vec![Box::new(rule)];
+        let walker = WorkbookWalker::new(&workbook, rules);
+        let violations = walker.walk();
 
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].rule_id, RuleId::Cpx501);

--- a/sheetrs/src/rules/cpx502_merged_cells.rs
+++ b/sheetrs/src/rules/cpx502_merged_cells.rs
@@ -2,12 +2,11 @@
 //!
 //! Description: Merged cells cause issues with sorting, filtering, and structural integrity.
 
-use super::{LinterContext, LinterRule, RuleCategory, WalkerRule};
-use crate::reader::{Sheet, Workbook};
+use super::{LinterContext, RuleCategory, WalkerRule};
+use crate::reader::Sheet;
 use crate::violation::{
     CellReference, FormatContext, RuleId, Severity, Violation, ViolationData, ViolationScope,
 };
-use anyhow::Result;
 
 /// Rule that detects merged cells
 pub struct MergedCellsRule;
@@ -29,38 +28,6 @@ impl ViolationData for MergedCellsData {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
-    }
-}
-
-impl LinterRule for MergedCellsRule {
-    fn id(&self) -> RuleId {
-        RuleId::Cpx502
-    }
-
-    fn name(&self) -> &str {
-        "Merged Cells"
-    }
-
-    fn category(&self) -> RuleCategory {
-        RuleCategory::Complexity
-    }
-
-    fn check(&self, workbook: &Workbook) -> Result<Vec<Violation>> {
-        let mut violations = Vec::new();
-
-        for sheet in &workbook.sheets {
-            for &(start_row, start_col, end_row, end_col) in &sheet.merged_cells {
-                let range_str = format_merged_range(start_row, start_col, end_row, end_col);
-                violations.push(Violation::new(
-                    RuleId::Cpx502,
-                    ViolationScope::Sheet(sheet.sheet_index),
-                    format!("Merged cells in range: {}", range_str),
-                    Severity::Warning,
-                ));
-            }
-        }
-
-        Ok(violations)
     }
 }
 
@@ -95,17 +62,12 @@ impl WalkerRule for MergedCellsRule {
     }
 }
 
-/// Format a merged cell range
-fn format_merged_range(start_row: u32, start_col: u32, end_row: u32, end_col: u32) -> String {
-    let start = CellReference::new(start_row, start_col);
-    let end = CellReference::new(end_row, end_col);
-    format!("{}:{}", start, end)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::reader::Workbook;
     use crate::reader::workbook::Sheet;
+    use crate::rules::walker::WorkbookWalker;
     use std::path::PathBuf;
 
     #[test]
@@ -124,7 +86,9 @@ mod tests {
         };
 
         let rule = MergedCellsRule;
-        let violations = rule.check(&workbook).unwrap();
+        let rules: Vec<Box<dyn WalkerRule>> = vec![Box::new(rule)];
+        let walker = WorkbookWalker::new(&workbook, rules);
+        let violations = walker.walk();
 
         assert_eq!(violations.len(), 2);
         assert_eq!(violations[0].rule_id, RuleId::Cpx502);
@@ -144,7 +108,9 @@ mod tests {
         };
 
         let rule = MergedCellsRule;
-        let violations = rule.check(&workbook).unwrap();
+        let rules: Vec<Box<dyn WalkerRule>> = vec![Box::new(rule)];
+        let walker = WorkbookWalker::new(&workbook, rules);
+        let violations = walker.walk();
 
         assert_eq!(violations.len(), 0);
     }

--- a/sheetrs/src/rules/dat706_numeric_text_calc.rs
+++ b/sheetrs/src/rules/dat706_numeric_text_calc.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Identifies mathematical operations involving strings that look like numbers.
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies numeric string calculations
 pub struct NumericTextCalcRule;
 
-impl LinterRule for NumericTextCalcRule {
+impl WalkerRule for NumericTextCalcRule {
     fn id(&self) -> RuleId {
         RuleId::Data706
     }
@@ -21,10 +19,5 @@ impl LinterRule for NumericTextCalcRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Data
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/dat707_validation_miss.rs
+++ b/sheetrs/src/rules/dat707_validation_miss.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Flags data points violating defined spreadsheet input constraints.
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies validation failures
 pub struct ValidationMissRule;
 
-impl LinterRule for ValidationMissRule {
+impl WalkerRule for ValidationMissRule {
     fn id(&self) -> RuleId {
         RuleId::Data707
     }
@@ -21,10 +19,5 @@ impl LinterRule for ValidationMissRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Data
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/int401_interrupted_by_data.rs
+++ b/sheetrs/src/rules/int401_interrupted_by_data.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Detects data entries that break a consistent formula pattern in a row or column.
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies formulas interrupted by raw data
 pub struct InterruptedByDataRule;
 
-impl LinterRule for InterruptedByDataRule {
+impl WalkerRule for InterruptedByDataRule {
     fn id(&self) -> RuleId {
         RuleId::Int401
     }
@@ -21,10 +19,5 @@ impl LinterRule for InterruptedByDataRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Interruptions
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/int402_interrupted_by_empty.rs
+++ b/sheetrs/src/rules/int402_interrupted_by_empty.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Identifies empty cells that break a consistent formula pattern in a row or column.
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies formulas interrupted by empty cells
 pub struct InterruptedByEmptyRule;
 
-impl LinterRule for InterruptedByEmptyRule {
+impl WalkerRule for InterruptedByEmptyRule {
     fn id(&self) -> RuleId {
         RuleId::Int402
     }
@@ -21,10 +19,5 @@ impl LinterRule for InterruptedByEmptyRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Interruptions
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/int403_interrupted_by_other.rs
+++ b/sheetrs/src/rules/int403_interrupted_by_other.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Flags formulas that break a pattern of consistent formulas (e.g., A1=B1+C1, A2=SUM(B2:C2), A3=B3+C3).
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies formulas interrupted by a different formula type
 pub struct InterruptedByOtherRule;
 
-impl LinterRule for InterruptedByOtherRule {
+impl WalkerRule for InterruptedByOtherRule {
     fn id(&self) -> RuleId {
         RuleId::Int403
     }
@@ -21,10 +19,5 @@ impl LinterRule for InterruptedByOtherRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Interruptions
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/mod.rs
+++ b/sheetrs/src/rules/mod.rs
@@ -81,7 +81,6 @@ pub mod vba1101_has_macros;
 
 use crate::reader::{Cell, Sheet, Workbook};
 use crate::violation::{ExcelError, RuleId, Violation};
-use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 
 /// Type alias for cell dependency graph: (SheetIndex, Row, Col) -> Vec<(SheetIndex, Row, Col)>
@@ -137,21 +136,6 @@ pub trait WalkerRule: Send + Sync {
     fn on_workbook_end(&self, _workbook: &Workbook, _ctx: &mut LinterContext) -> Vec<Violation> {
         Vec::new()
     }
-}
-
-/// Trait that all linter rules must implement
-pub trait LinterRule: Send + Sync {
-    /// Unique rule identifier
-    fn id(&self) -> RuleId;
-
-    /// Human-readable rule name
-    fn name(&self) -> &str;
-
-    /// Rule category
-    fn category(&self) -> RuleCategory;
-
-    /// Check the workbook for violations
-    fn check(&self, workbook: &Workbook) -> Result<Vec<Violation>>;
 }
 
 /// Rule categories matching the comparative report sections

--- a/sheetrs/src/rules/ref308_current_sheet_ref.rs
+++ b/sheetrs/src/rules/ref308_current_sheet_ref.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Detects formulas that explicitly reference the sheet they are already on.
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies formulas with redundant current sheet references
 pub struct CurrentSheetRefRule;
 
-impl LinterRule for CurrentSheetRefRule {
+impl WalkerRule for CurrentSheetRefRule {
     fn id(&self) -> RuleId {
         RuleId::Ref308
     }
@@ -21,10 +19,5 @@ impl LinterRule for CurrentSheetRefRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Reference
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/ref309_ref_to_empty_cell.rs
+++ b/sheetrs/src/rules/ref309_ref_to_empty_cell.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Flags formulas referencing cells that contain no data or formulas.
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies formulas referencing empty cells
 pub struct RefToEmptyCellRule;
 
-impl LinterRule for RefToEmptyCellRule {
+impl WalkerRule for RefToEmptyCellRule {
     fn id(&self) -> RuleId {
         RuleId::Ref309
     }
@@ -21,10 +19,5 @@ impl LinterRule for RefToEmptyCellRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Reference
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/ref310_longer_ref_expected.rs
+++ b/sheetrs/src/rules/ref310_longer_ref_expected.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Identifies cases where a reference stops abruptly before adjacent data (statistical outlier).
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies suspiciously short references
 pub struct LongerRefExpectedRule;
 
-impl LinterRule for LongerRefExpectedRule {
+impl WalkerRule for LongerRefExpectedRule {
     fn id(&self) -> RuleId {
         RuleId::Ref310
     }
@@ -21,10 +19,5 @@ impl LinterRule for LongerRefExpectedRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Reference
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/ref311_reference_to_pivot.rs
+++ b/sheetrs/src/rules/ref311_reference_to_pivot.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Detects direct cell-based references to pivot table data instead of using GETPIVOTDATA.
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies direct references to pivot table data
 pub struct ReferenceToPivotRule;
 
-impl LinterRule for ReferenceToPivotRule {
+impl WalkerRule for ReferenceToPivotRule {
     fn id(&self) -> RuleId {
         RuleId::Ref311
     }
@@ -21,10 +19,5 @@ impl LinterRule for ReferenceToPivotRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Reference
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/registry.rs
+++ b/sheetrs/src/rules/registry.rs
@@ -75,12 +75,8 @@ pub fn get_all_valid_tokens() -> HashSet<String> {
         tokens.insert(prefix.to_string());
     }
 
-    // Rule IDs from both legacy and walker rules
+    // Rule IDs from walker rules
     let config = LinterConfig::default();
-    let rules = create_all_rules(&config);
-    for rule in rules {
-        tokens.insert(rule.id().to_string());
-    }
     let walker_rules = create_all_walker_rules(&config);
     for rule in walker_rules {
         tokens.insert(rule.id().to_string());
@@ -101,104 +97,21 @@ pub struct RuleMetadata {
     pub is_default: bool,
 }
 
-/// Collect metadata from all rules (LinterRule + WalkerRule).
-///
-/// Deduplicates by `RuleId` so dual-impl rules appear only once.
+/// Collect metadata from all rules.
 pub fn get_all_rule_metadata(config: &LinterConfig) -> Vec<RuleMetadata> {
-    let mut seen = HashSet::new();
-    let mut metadata = Vec::new();
-
-    // Walker rules first (preferred source for migrated rules)
-    for rule in create_all_walker_rules(config) {
-        if seen.insert(rule.id()) {
-            metadata.push(RuleMetadata {
-                id: rule.id(),
-                name: rule.name().to_string(),
-                category: rule.category(),
-                is_default: DEFAULT_ACTIVE_RULES.contains(&rule.id()),
-            });
-        }
-    }
-
-    // Legacy LinterRules (skipped if already present from walker)
-    for rule in create_all_rules(config) {
-        if seen.insert(rule.id()) {
-            metadata.push(RuleMetadata {
-                id: rule.id(),
-                name: rule.name().to_string(),
-                category: rule.category(),
-                is_default: DEFAULT_ACTIVE_RULES.contains(&rule.id()),
-            });
-        }
-    }
+    let mut metadata: Vec<RuleMetadata> = create_all_walker_rules(config)
+        .into_iter()
+        .map(|rule| RuleMetadata {
+            id: rule.id(),
+            name: rule.name().to_string(),
+            category: rule.category(),
+            is_default: DEFAULT_ACTIVE_RULES.contains(&rule.id()),
+        })
+        .collect();
 
     // Sort by rule ID string for stable ordering
     metadata.sort_by(|a, b| a.id.as_str().cmp(b.id.as_str()));
     metadata
-}
-
-/// Create all enabled rules based on configuration
-pub fn create_enabled_rules(config: &LinterConfig) -> Vec<Box<dyn LinterRule>> {
-    let all_rules = create_all_rules(config);
-
-    all_rules
-        .into_iter()
-        .filter(|rule| {
-            let is_enabled_in_config = config.is_rule_enabled(rule.id().as_str());
-
-            if config.global.enabled_rules.is_empty() {
-                DEFAULT_ACTIVE_RULES.contains(&rule.id()) && is_enabled_in_config
-            } else {
-                is_enabled_in_config
-            }
-        })
-        .collect()
-}
-
-/// Create instances of all available rules
-pub fn create_all_rules(config: &LinterConfig) -> Vec<Box<dyn LinterRule>> {
-    vec![
-        // Excel Errors (1xx)
-        // err101, err102, err103 moved to walker
-        // Unreliable Calculations (2xx)
-        // calc201, calc202 moved to walker
-        Box::new(calc203_double_operator::DoubleOperatorRule),
-        Box::new(calc204_approximate_lookup::ApproximateLookupRule),
-        Box::new(calc205_double_count::DoubleCountRule),
-        // Reference Issues (3xx)
-        // ref301, ref302, ref303, ref304, ref305 moved to walker
-        // ref306, ref307 moved to walker
-        Box::new(ref308_current_sheet_ref::CurrentSheetRefRule),
-        Box::new(ref309_ref_to_empty_cell::RefToEmptyCellRule),
-        Box::new(ref310_longer_ref_expected::LongerRefExpectedRule),
-        Box::new(ref311_reference_to_pivot::ReferenceToPivotRule),
-        // Formula Interruptions (4xx)
-        Box::new(int401_interrupted_by_data::InterruptedByDataRule),
-        Box::new(int402_interrupted_by_empty::InterruptedByEmptyRule),
-        Box::new(int403_interrupted_by_other::InterruptedByOtherRule),
-        // Complexity (5xx)
-        // cpx501 through cpx509 moved to walker
-        // Vulnerable Formulas (6xx)
-        // vul601, vul602, vul603 moved to walker
-        Box::new(vul604_error_prone_functions::ErrorProneFunctionsRule::new(
-            config,
-        )),
-        Box::new(vul605_legacy_array::LegacyArrayRule),
-        Box::new(vul606_deprecated_func::DeprecatedFuncRule),
-        Box::new(vul607_unprotected::UnprotectedRule),
-        // Data Issues (7xx)
-        // dat701, dat702, dat703, dat704, dat705 moved to walker
-        Box::new(dat706_numeric_text_calc::NumericTextCalcRule),
-        Box::new(dat707_validation_miss::ValidationMissRule),
-        // External References (8xx)
-        // ext801, ext802 moved to walker
-        // Hidden Information (9xx)
-        // hid901, hid902 moved to walker
-        // Files & Settings (10xx)
-        // file1001, file1002, file1003 moved to walker
-        // VBA Issues (11xx)
-        // vba1101 moved to walker
-    ]
 }
 
 /// Create instances of all available walker rules
@@ -212,47 +125,63 @@ pub fn create_all_walker_rules(config: &LinterConfig) -> Vec<Box<dyn WalkerRule>
         // ERR102/ERR103 after CALC202 so on_workbook_end reads circular_cells
         Box::new(err102_error_cells::ErrorCellsRule),
         Box::new(err103_ref_to_error::RefToErrorRule),
+        Box::new(calc203_double_operator::DoubleOperatorRule),
+        Box::new(calc204_approximate_lookup::ApproximateLookupRule),
+        Box::new(calc205_double_count::DoubleCountRule),
         // Reference Issues (3xx)
         Box::new(ref301_unused_named_ranges::UnusedNamedRangesRule::new()),
         Box::new(ref302_duplicate_names::DuplicateSheetNamesRule),
         Box::new(ref303_empty_sheets::EmptySheetsRule),
+        Box::new(ref304_large_used_range::LargeUsedRangeRule::new()),
+        Box::new(ref305_blank_rows_columns::BlankRowsColumnsRule::new()),
         Box::new(ref306_unused_sheets::UnusedSheetsRule),
+        Box::new(ref307_whole_column_row_refs::WholeColumnRowRefsRule::new()),
+        Box::new(ref308_current_sheet_ref::CurrentSheetRefRule),
+        Box::new(ref309_ref_to_empty_cell::RefToEmptyCellRule),
+        Box::new(ref310_longer_ref_expected::LongerRefExpectedRule),
+        Box::new(ref311_reference_to_pivot::ReferenceToPivotRule),
+        // Formula Interruptions (4xx)
+        Box::new(int401_interrupted_by_data::InterruptedByDataRule),
+        Box::new(int402_interrupted_by_empty::InterruptedByEmptyRule),
+        Box::new(int403_interrupted_by_other::InterruptedByOtherRule),
         // Complexity (5xx)
         Box::new(cpx501_sheet_counts::ExcessiveSheetCountsRule::new(config)),
         Box::new(cpx502_merged_cells::MergedCellsRule),
-        // Data Issues (7xx)
-        Box::new(dat701_sheet_names::NonDescriptiveSheetNameRule::new(config)),
-        Box::new(dat702_numeric_formats::InconsistentNumberFormatRule::new()),
-        Box::new(dat703_date_formats::InconsistentDateFormatRule::new(config)),
-        Box::new(dat704_long_text::LongTextCellRule::new(config)),
-        Box::new(dat705_unnecessary_space::UnnecessarySpaceRule),
-        // Complexity (5xx)
         Box::new(
             cpx503_excessive_conditional_formatting::ExcessiveConditionalFormattingRule::new(
                 config,
             ),
         ),
-        // Vulnerability (6xx)
-        Box::new(vul601_duplicate_formulas::DuplicateFormulasRule::new()),
-        Box::new(vul602_volatile_functions::VolatileFunctionsRule::new()),
-        Box::new(vul603_empty_string_test::EmptyStringTestRule::new()),
-        // Reference (3xx)
-        Box::new(ref304_large_used_range::LargeUsedRangeRule::new()),
-        Box::new(ref305_blank_rows_columns::BlankRowsColumnsRule::new()),
-        Box::new(ref307_whole_column_row_refs::WholeColumnRowRefsRule::new()),
-        // Complexity (5xx)
         Box::new(cpx504_deep_if_nesting::DeepIfNestingRule::new(config)),
         Box::new(cpx505_deep_formula_nesting::DeepFormulaNestingRule),
         Box::new(cpx506_many_operations::ManyOperationsRule),
         Box::new(cpx507_multiple_sheet_ref::MultipleSheetRefRule::new(config)),
         Box::new(cpx508_many_references::ManyReferencesRule),
         Box::new(cpx509_long_formula::LongFormulaRule),
-        // Hidden Information (9xx)
-        Box::new(hid901_hidden_worksheet::HiddenWorksheetRule),
-        Box::new(hid902_hidden_columns_rows::HiddenColumnsRowsRule),
+        // Vulnerable Formulas (6xx)
+        Box::new(vul601_duplicate_formulas::DuplicateFormulasRule::new()),
+        Box::new(vul602_volatile_functions::VolatileFunctionsRule::new()),
+        Box::new(vul603_empty_string_test::EmptyStringTestRule::new()),
+        Box::new(vul604_error_prone_functions::ErrorProneFunctionsRule::new(
+            config,
+        )),
+        Box::new(vul605_legacy_array::LegacyArrayRule),
+        Box::new(vul606_deprecated_func::DeprecatedFuncRule),
+        Box::new(vul607_unprotected::UnprotectedRule),
+        // Data Issues (7xx)
+        Box::new(dat701_sheet_names::NonDescriptiveSheetNameRule::new(config)),
+        Box::new(dat702_numeric_formats::InconsistentNumberFormatRule::new()),
+        Box::new(dat703_date_formats::InconsistentDateFormatRule::new(config)),
+        Box::new(dat704_long_text::LongTextCellRule::new(config)),
+        Box::new(dat705_unnecessary_space::UnnecessarySpaceRule),
+        Box::new(dat706_numeric_text_calc::NumericTextCalcRule),
+        Box::new(dat707_validation_miss::ValidationMissRule),
         // External References (8xx)
         Box::new(ext801_external_workbook::ExternalWorkbooksRule::new()),
         Box::new(ext802_web_urls::WebUrlsRule::new(config)),
+        // Hidden Information (9xx)
+        Box::new(hid901_hidden_worksheet::HiddenWorksheetRule),
+        Box::new(hid902_hidden_columns_rows::HiddenColumnsRowsRule),
         // Files & Settings (10xx)
         Box::new(file1001_large_file_size::LargeFileSizeRule::new(config)),
         Box::new(file1002_old_spreadsheet::OldSpreadsheetRule::new(config)),
@@ -290,20 +219,25 @@ pub fn clone_walker_rule(rule: &dyn WalkerRule, config: &LinterConfig) -> Box<dy
             Box::new(calc201_hardcoded_values::HardcodedValuesInFormulasRule::new(config))
         }
         RuleId::Calc202 => Box::new(calc202_circular_references::CircularReferenceRule::new()),
+        RuleId::Calc203 => Box::new(calc203_double_operator::DoubleOperatorRule),
+        RuleId::Calc204 => Box::new(calc204_approximate_lookup::ApproximateLookupRule),
+        RuleId::Calc205 => Box::new(calc205_double_count::DoubleCountRule),
         RuleId::Ref301 => Box::new(ref301_unused_named_ranges::UnusedNamedRangesRule::new()),
         RuleId::Ref302 => Box::new(ref302_duplicate_names::DuplicateSheetNamesRule),
         RuleId::Ref303 => Box::new(ref303_empty_sheets::EmptySheetsRule),
-        RuleId::Ref306 => Box::new(ref306_unused_sheets::UnusedSheetsRule),
         RuleId::Ref304 => Box::new(ref304_large_used_range::LargeUsedRangeRule::new()),
         RuleId::Ref305 => Box::new(ref305_blank_rows_columns::BlankRowsColumnsRule::new()),
+        RuleId::Ref306 => Box::new(ref306_unused_sheets::UnusedSheetsRule),
+        RuleId::Ref307 => Box::new(ref307_whole_column_row_refs::WholeColumnRowRefsRule::new()),
+        RuleId::Ref308 => Box::new(ref308_current_sheet_ref::CurrentSheetRefRule),
+        RuleId::Ref309 => Box::new(ref309_ref_to_empty_cell::RefToEmptyCellRule),
+        RuleId::Ref310 => Box::new(ref310_longer_ref_expected::LongerRefExpectedRule),
+        RuleId::Ref311 => Box::new(ref311_reference_to_pivot::ReferenceToPivotRule),
+        RuleId::Int401 => Box::new(int401_interrupted_by_data::InterruptedByDataRule),
+        RuleId::Int402 => Box::new(int402_interrupted_by_empty::InterruptedByEmptyRule),
+        RuleId::Int403 => Box::new(int403_interrupted_by_other::InterruptedByOtherRule),
         RuleId::Cpx501 => Box::new(cpx501_sheet_counts::ExcessiveSheetCountsRule::new(config)),
         RuleId::Cpx502 => Box::new(cpx502_merged_cells::MergedCellsRule),
-        RuleId::Data701 => Box::new(dat701_sheet_names::NonDescriptiveSheetNameRule::new(config)),
-        RuleId::Ext801 => Box::new(ext801_external_workbook::ExternalWorkbooksRule::new()),
-        RuleId::Ext802 => Box::new(ext802_web_urls::WebUrlsRule::new(config)),
-        RuleId::Hid901 => Box::new(hid901_hidden_worksheet::HiddenWorksheetRule),
-        RuleId::Hid902 => Box::new(hid902_hidden_columns_rows::HiddenColumnsRowsRule),
-        RuleId::Ref307 => Box::new(ref307_whole_column_row_refs::WholeColumnRowRefsRule::new()),
         RuleId::Cpx503 => Box::new(
             cpx503_excessive_conditional_formatting::ExcessiveConditionalFormattingRule::new(
                 config,
@@ -318,15 +252,27 @@ pub fn clone_walker_rule(rule: &dyn WalkerRule, config: &LinterConfig) -> Box<dy
         RuleId::Vul601 => Box::new(vul601_duplicate_formulas::DuplicateFormulasRule::new()),
         RuleId::Vul602 => Box::new(vul602_volatile_functions::VolatileFunctionsRule::new()),
         RuleId::Vul603 => Box::new(vul603_empty_string_test::EmptyStringTestRule::new()),
+        RuleId::Vul604 => Box::new(vul604_error_prone_functions::ErrorProneFunctionsRule::new(
+            config,
+        )),
+        RuleId::Vul605 => Box::new(vul605_legacy_array::LegacyArrayRule),
+        RuleId::Vul606 => Box::new(vul606_deprecated_func::DeprecatedFuncRule),
+        RuleId::Vul607 => Box::new(vul607_unprotected::UnprotectedRule),
+        RuleId::Data701 => Box::new(dat701_sheet_names::NonDescriptiveSheetNameRule::new(config)),
         RuleId::Data702 => Box::new(dat702_numeric_formats::InconsistentNumberFormatRule::new()),
         RuleId::Data703 => Box::new(dat703_date_formats::InconsistentDateFormatRule::new(config)),
         RuleId::Data704 => Box::new(dat704_long_text::LongTextCellRule::new(config)),
         RuleId::Data705 => Box::new(dat705_unnecessary_space::UnnecessarySpaceRule),
+        RuleId::Data706 => Box::new(dat706_numeric_text_calc::NumericTextCalcRule),
+        RuleId::Data707 => Box::new(dat707_validation_miss::ValidationMissRule),
+        RuleId::Ext801 => Box::new(ext801_external_workbook::ExternalWorkbooksRule::new()),
+        RuleId::Ext802 => Box::new(ext802_web_urls::WebUrlsRule::new(config)),
+        RuleId::Hid901 => Box::new(hid901_hidden_worksheet::HiddenWorksheetRule),
+        RuleId::Hid902 => Box::new(hid902_hidden_columns_rows::HiddenColumnsRowsRule),
         RuleId::File1001 => Box::new(file1001_large_file_size::LargeFileSizeRule::new(config)),
         RuleId::File1002 => Box::new(file1002_old_spreadsheet::OldSpreadsheetRule::new(config)),
         RuleId::File1003 => Box::new(file1003_date_system_1904::DateSystem1904Rule::new()),
         RuleId::Vba1101 => Box::new(vba1101_has_macros::HasMacrosRule),
-        _ => panic!("Unknown walker rule: {:?}", rule.id()),
     }
 }
 
@@ -338,7 +284,6 @@ mod tests {
     fn test_prefix_activation() {
         let mut config = LinterConfig::default();
         config.global.enabled_rules.insert("ERR".to_string());
-        // ERR102 is now a walker rule
         let enabled = create_enabled_walker_rules(&config);
         assert!(enabled.iter().any(|r| r.id() == RuleId::Err102));
     }

--- a/sheetrs/src/rules/vul604_error_prone_functions.rs
+++ b/sheetrs/src/rules/vul604_error_prone_functions.rs
@@ -2,9 +2,9 @@
 //!
 //! Description: Detects Excel functions that are susceptible to generating errors (currently focuses on VLOOKUP/HLOOKUP).
 
-use super::{LinterRule, RuleCategory};
+use super::{LinterContext, RuleCategory, WalkerRule};
 use crate::config::LinterConfig;
-use crate::reader::Workbook;
+use crate::reader::{Cell, Sheet};
 use crate::violation::{RuleId, Severity, Violation, ViolationScope};
 
 /// Rule that detects error-prone functions like VLOOKUP and HLOOKUP.
@@ -16,7 +16,7 @@ impl ErrorProneFunctionsRule {
     }
 }
 
-impl LinterRule for ErrorProneFunctionsRule {
+impl WalkerRule for ErrorProneFunctionsRule {
     fn id(&self) -> RuleId {
         RuleId::Vul604
     }
@@ -29,33 +29,28 @@ impl LinterRule for ErrorProneFunctionsRule {
         RuleCategory::Vulnerability
     }
 
-    fn check(&self, workbook: &Workbook) -> anyhow::Result<Vec<Violation>> {
+    fn on_cell(&self, sheet: &Sheet, cell: &Cell, _ctx: &mut LinterContext) -> Vec<Violation> {
         let mut violations = Vec::new();
 
-        for sheet in &workbook.sheets {
-            for ((row, col), cell) in &sheet.cells {
-                if let Some(formula) = cell.as_formula() {
-                    let upper_formula = formula.to_uppercase();
-                    if upper_formula.contains("VLOOKUP(") || upper_formula.contains("HLOOKUP(") {
-                        violations.push(Violation::new(
-                            RuleId::Vul604,
-                            ViolationScope::Cell(
-                                sheet.sheet_index,
-                                crate::violation::CellReference {
-                                    row: *row,
-                                    col: *col,
-                                },
-                            ),
-                            "Avoid using VLOOKUP/HLOOKUP. Use XLOOKUP or INDEX/MATCH instead."
-                                .to_string(),
-                            Severity::Warning,
-                        ));
-                    }
-                }
+        if let Some(formula) = cell.as_formula() {
+            let upper_formula = formula.to_uppercase();
+            if upper_formula.contains("VLOOKUP(") || upper_formula.contains("HLOOKUP(") {
+                violations.push(Violation::new(
+                    RuleId::Vul604,
+                    ViolationScope::Cell(
+                        sheet.sheet_index,
+                        crate::violation::CellReference {
+                            row: cell.row,
+                            col: cell.col,
+                        },
+                    ),
+                    "Avoid using VLOOKUP/HLOOKUP. Use XLOOKUP or INDEX/MATCH instead.".to_string(),
+                    Severity::Warning,
+                ));
             }
         }
 
-        Ok(violations)
+        violations
     }
 }
 
@@ -63,7 +58,8 @@ impl LinterRule for ErrorProneFunctionsRule {
 mod tests {
     use super::*;
     use crate::reader::workbook::CellValue;
-    use crate::reader::{Cell, Sheet};
+    use crate::reader::{Cell, Sheet, Workbook};
+    use crate::rules::walker::WorkbookWalker;
     use std::collections::HashMap;
     use std::path::PathBuf;
 
@@ -124,8 +120,9 @@ mod tests {
 
         let config = LinterConfig::default();
         let rule = ErrorProneFunctionsRule::new(&config);
-
-        let violations = rule.check(&workbook).unwrap();
+        let rules: Vec<Box<dyn WalkerRule>> = vec![Box::new(rule)];
+        let walker = WorkbookWalker::new(&workbook, rules);
+        let violations = walker.walk();
 
         assert_eq!(violations.len(), 2);
     }

--- a/sheetrs/src/rules/vul605_legacy_array.rs
+++ b/sheetrs/src/rules/vul605_legacy_array.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Detects antiquated CSE formulas that may fail in modern Excel versions.
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies legacy array formulas
 pub struct LegacyArrayRule;
 
-impl LinterRule for LegacyArrayRule {
+impl WalkerRule for LegacyArrayRule {
     fn id(&self) -> RuleId {
         RuleId::Vul605
     }
@@ -21,10 +19,5 @@ impl LinterRule for LegacyArrayRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Vulnerability
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/vul606_deprecated_func.rs
+++ b/sheetrs/src/rules/vul606_deprecated_func.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Identifies functions superseded by modern alternatives (e.g., CONCATENATE vs CONCAT).
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies deprecated functions
 pub struct DeprecatedFuncRule;
 
-impl LinterRule for DeprecatedFuncRule {
+impl WalkerRule for DeprecatedFuncRule {
     fn id(&self) -> RuleId {
         RuleId::Vul606
     }
@@ -21,10 +19,5 @@ impl LinterRule for DeprecatedFuncRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Vulnerability
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/rules/vul607_unprotected.rs
+++ b/sheetrs/src/rules/vul607_unprotected.rs
@@ -2,15 +2,13 @@
 //!
 //! Description: Flags formulas in cells capable of being overwritten accidentally (missing protection).
 
-use super::{LinterRule, RuleCategory};
-use crate::reader::Workbook;
-use crate::violation::{RuleId, Violation};
-use anyhow::Result;
+use super::{RuleCategory, WalkerRule};
+use crate::violation::RuleId;
 
 /// Rule that identifies unprotected formulas
 pub struct UnprotectedRule;
 
-impl LinterRule for UnprotectedRule {
+impl WalkerRule for UnprotectedRule {
     fn id(&self) -> RuleId {
         RuleId::Vul607
     }
@@ -21,10 +19,5 @@ impl LinterRule for UnprotectedRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Vulnerability
-    }
-
-    fn check(&self, _workbook: &Workbook) -> Result<Vec<Violation>> {
-        // Placeholder implementation
-        Ok(Vec::new())
     }
 }

--- a/sheetrs/src/violation.rs
+++ b/sheetrs/src/violation.rs
@@ -530,11 +530,11 @@ pub trait ViolationData: fmt::Debug + Send + Sync {
 
 /// Internal storage for violation messages.
 ///
-/// Supports two paths: legacy pre-formatted strings (used by [`LinterRule`]
-/// implementations) and deferred data (used by [`WalkerRule`] implementations).
+/// Supports two paths: pre-formatted strings and deferred data
+/// (used by rules implementing [`ViolationData`]).
 #[derive(Debug, Clone)]
 enum ViolationMessageInner {
-    /// Pre-formatted message string (legacy `LinterRule` path).
+    /// Pre-formatted message string.
     Legacy(String),
     /// Compact incident data with deferred formatting (walker path).
     Data(Arc<dyn ViolationData>),
@@ -556,8 +556,8 @@ pub struct Violation {
 impl Violation {
     /// Creates a new violation with a pre-formatted message string.
     ///
-    /// Used by legacy [`LinterRule`] implementations. Walker rules should
-    /// prefer [`with_data`](Violation::with_data).
+    /// Prefer [`with_data`](Violation::with_data) for compact, deferred
+    /// formatting when a [`ViolationData`] struct is available.
     pub fn new(
         rule_id: RuleId,
         scope: ViolationScope,


### PR DESCRIPTION
## Description

Eliminate the legacy `LinterRule` trait entirely, migrating all 17 remaining implementations to the unified `WalkerRule` trait. This consolidates the rule engine into a single-pass `WorkbookWalker` traversal system, reducing code duplication and simplifying the architecture.

This was identified as the lowest-effort, highest-impact improvement in the agent readiness assessment.

## Changes

- **13 placeholder stubs** migrated from `LinterRule` to `WalkerRule` (CALC203–205, REF308–311, INT401–403, VUL605–607, DAT706–707)
- **1 real implementation** migrated: VUL604 (`ErrorProneFunctionsRule`) — check logic moved from `check()` to `on_cell()`
- **3 dual-implementations** cleaned up: CPX501, CPX502, CALC202 — removed redundant `LinterRule` impl blocks
- **Removed** `LinterRule` trait definition from `rules/mod.rs`
- **Removed** `create_all_rules()` and `create_enabled_rules()` from `registry.rs`
- **Removed** legacy rule loop from `Linter::lint_workbook()` in `lib.rs`
- **Removed** `pub use rules::LinterRule` re-export
- **Updated** `sheetrs-wasm` to use `get_all_rule_metadata()` instead of removed `create_all_rules()`
- **Updated** `violation.rs` doc comments to remove `LinterRule` references
- **Updated** `ARCHITECTURE.md` and `docs/coding-patterns.md` to reflect unified architecture

**Net result: -614 lines deleted, +193 lines added across 27 files.**

## Testing

- [x] `cargo test` passes (141 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` passes (no new lints; pre-existing parser lints only)
- [x] `cargo fmt --check` passes
- [x] Tested with `tests/minimal_test.xlsx` and `tests/minimal_test.ods` (parity check via `cargo test --release`)

## Changelog

- [x] Added a changelog fragment in `changelog.d/` (see [CONTRIBUTING.md](CONTRIBUTING.md#changelog-fragments))