### PR TITLE
perf: use static LazyLock<Regex> for CALC201, CALC202, REF307, VUL603

### DIFF
--- a/changelog.d/static-regex-rules.changed.md
+++ b/changelog.d/static-regex-rules.changed.md
@@ -1,0 +1,1 @@
+Use static `LazyLock<Regex>` for CALC201, CALC202, REF307, and VUL603 rules to avoid redundant regex compilation on every rule instantiation.

--- a/sheetrs/src/reader/ods_parser.rs
+++ b/sheetrs/src/reader/ods_parser.rs
@@ -102,7 +102,8 @@ fn parse_ods_date(date_str: &str) -> Option<f64> {
     // Total days from year 0 to the start of `y` (Jan 1 of year y).
     // Leap year corrections use (y-1) to count leap years in [0, y-1] only;
     // using y would erroneously include year y's own leap day.
-    let days_before_year = |y: i32| -> i32 { 365 * y + (y - 1) / 4 - (y - 1) / 100 + (y - 1) / 400 };
+    let days_before_year =
+        |y: i32| -> i32 { 365 * y + (y - 1) / 4 - (y - 1) / 100 + (y - 1) / 400 };
 
     let leap_feb = if month > 2 && is_leap(year) { 1 } else { 0 };
     let absolute_days =

--- a/sheetrs/src/rules/calc201_hardcoded_values.rs
+++ b/sheetrs/src/rules/calc201_hardcoded_values.rs
@@ -11,6 +11,21 @@ use crate::violation::{
     CellReference, FormatContext, RuleId, Severity, Violation, ViolationData, ViolationScope,
 };
 use regex::Regex;
+use std::sync::LazyLock;
+
+/// Matches quoted strings (to strip before number extraction).
+static STRING_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#""[^"]*""#).expect("CALC201 string regex must compile"));
+
+/// Matches external workbook references like `[1]`, `[2]`.
+static EXTERNAL_REF_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[(\d+)\]").expect("CALC201 external ref regex must compile"));
+
+/// Matches numeric literals (integers and decimals).
+/// `\b` prevents matching digits inside cell references (e.g. "A1") or
+/// function names (e.g. "LOG10").
+static NUMBER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b(\d+(\.\d+)?)\b").expect("CALC201 number regex must compile"));
 
 /// Rule that detects hardcoded numeric values in formulas.
 ///
@@ -19,24 +34,13 @@ use regex::Regex;
 /// per cell listing every unique hardcoded constant found.
 pub struct HardcodedValuesInFormulasRule {
     config: LinterConfig,
-    /// Regex to match quoted strings (to ignore them)
-    string_regex: Regex,
-    /// Regex to match external workbook references like `[1]`, `[2]`
-    external_ref_regex: Regex,
-    /// Regex to match numeric literals (integers and decimals)
-    number_regex: Regex,
 }
 
 impl HardcodedValuesInFormulasRule {
-    /// Create a new rule instance with pre-compiled regexes.
+    /// Create a new rule instance.
     pub fn new(config: &LinterConfig) -> Self {
         Self {
             config: config.clone(),
-            string_regex: Regex::new(r#""[^"]*""#).unwrap(),
-            external_ref_regex: Regex::new(r"\[(\d+)\]").unwrap(),
-            // Matches integers and decimals. \b prevents matching digits inside
-            // cell references (e.g. "A1") or function names (e.g. "LOG10").
-            number_regex: Regex::new(r"\b(\d+(\.\d+)?)\b").unwrap(),
         }
     }
 
@@ -84,18 +88,17 @@ impl HardcodedValuesInFormulasRule {
         ignore_pow10: bool,
     ) -> Vec<f64> {
         // Remove strings first
-        let formula_no_strings = self.string_regex.replace_all(formula, "");
+        let formula_no_strings = STRING_RE.replace_all(formula, "");
 
         // Collect positions of external workbook references to exclude
-        let excluded_ranges: Vec<(usize, usize)> = self
-            .external_ref_regex
+        let excluded_ranges: Vec<(usize, usize)> = EXTERNAL_REF_RE
             .captures_iter(&formula_no_strings)
             .filter_map(|cap| cap.get(0).map(|m| (m.start(), m.end())))
             .collect();
 
         let mut values = Vec::new();
 
-        for cap in self.number_regex.captures_iter(&formula_no_strings) {
+        for cap in NUMBER_RE.captures_iter(&formula_no_strings) {
             if let Some(match_str) = cap.get(1) {
                 let match_start = match_str.start();
                 let match_end = match_str.end();

--- a/sheetrs/src/rules/calc202_circular_references.rs
+++ b/sheetrs/src/rules/calc202_circular_references.rs
@@ -9,6 +9,19 @@ use crate::violation::{
 };
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+/// Compiled cell-reference pattern, shared across all rule instances.
+///
+/// Matches cell references like A1, $A$1, Sheet1!A1, 'Sheet Name'!A1, A1:B2.
+/// Groups: 1=sheet wrapper, 2=quoted sheet, 3=unquoted sheet,
+///         4=start col, 5=start row, 6=end col (opt), 7=end row (opt).
+static CELL_REF_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?:('([^']+)'|([A-Za-z0-9_\.]+))!)?\$?([A-Za-z]+)\$?([0-9]+)(?::\$?([A-Za-z]+)\$?([0-9]+))?",
+    )
+    .expect("CALC202 cell reference regex must compile")
+});
 
 /// Rule that detects circular references in formulas.
 ///
@@ -23,30 +36,17 @@ use std::collections::{HashMap, HashSet};
 ///
 /// Note: Whole column/row references (e.g., `A:A`, `1:1`) are not matched by the cell reference
 /// pattern and are flagged by rule REF307.
-pub struct CircularReferenceRule {
-    cell_ref_pattern: Regex,
-}
+pub struct CircularReferenceRule;
 
 impl CircularReferenceRule {
     pub fn new() -> Self {
-        // Regex to match cell references (e.g., A1, $A$1, Sheet1!A1, 'Sheet Name'!A1, A1:B2)
-        // Group 1: Sheet name (optional) - either quoted or unquoted
-        // Group 4: Start column
-        // Group 5: Start row
-        // Group 6: End column (optional)
-        // Group 7: End row (optional)
-        let cell_ref_pattern = Regex::new(
-            r"(?:('([^']+)'|([A-Za-z0-9_\.]+))!)?\$?([A-Za-z]+)\$?([0-9]+)(?::\$?([A-Za-z]+)\$?([0-9]+))?",
-        )
-        .unwrap();
-
-        Self { cell_ref_pattern }
+        Self
     }
 }
 
 impl Default for CircularReferenceRule {
     fn default() -> Self {
-        Self::new()
+        Self
     }
 }
 
@@ -97,7 +97,7 @@ impl WalkerRule for CircularReferenceRule {
         if let Some(formula) = cell.as_formula() {
             let refs = extract_cell_references(
                 formula,
-                &self.cell_ref_pattern,
+                &CELL_REF_PATTERN,
                 sheet.sheet_index,
                 &ctx.name_to_index,
             );

--- a/sheetrs/src/rules/ref307_whole_column_row_refs.rs
+++ b/sheetrs/src/rules/ref307_whole_column_row_refs.rs
@@ -10,27 +10,29 @@ use crate::violation::{
 };
 use regex::Regex;
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
+
+/// Matches whole-column references (A:A, A:Z, etc.).
+static COLUMN_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b[A-Z]+:[A-Z]+\b").expect("REF307 column regex must compile"));
+
+/// Matches whole-row references (1:1, 1:100, etc.).
+static ROW_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b\d+:\d+\b").expect("REF307 row regex must compile"));
 
 /// Per-sheet cell collection: sheet_index → Vec<(row, col, is_column)>.
 type SheetCellMap = Mutex<HashMap<u16, Vec<(u32, u32, bool)>>>;
 
 /// Rule that detects whole-column (e.g., A:A) or whole-row (e.g., 1:1) references.
 pub struct WholeColumnRowRefsRule {
-    /// Regex pattern for whole column references (A:A, A:Z, etc.).
-    column_pattern: Regex,
-    /// Regex pattern for whole row references (1:1, 1:100, etc.).
-    row_pattern: Regex,
     /// Per-sheet collected cells.
     sheet_cells: SheetCellMap,
 }
 
 impl WholeColumnRowRefsRule {
-    /// Create a new instance with compiled regex.
+    /// Create a new instance.
     pub fn new() -> Self {
         Self {
-            column_pattern: Regex::new(r"\b[A-Z]+:[A-Z]+\b").unwrap(),
-            row_pattern: Regex::new(r"\b\d+:\d+\b").unwrap(),
             sheet_cells: Mutex::new(HashMap::new()),
         }
     }
@@ -99,8 +101,8 @@ impl WalkerRule for WholeColumnRowRefsRule {
         if let Some(formula) = cell.as_formula() {
             let formula_upper = formula.to_uppercase();
 
-            let has_column = self.column_pattern.is_match(&formula_upper);
-            let has_row = !has_column && self.row_pattern.is_match(&formula_upper);
+            let has_column = COLUMN_PATTERN.is_match(&formula_upper);
+            let has_row = !has_column && ROW_PATTERN.is_match(&formula_upper);
 
             if has_column || has_row {
                 let mut map = self.sheet_cells.lock().unwrap();

--- a/sheetrs/src/rules/vul603_empty_string_test.rs
+++ b/sheetrs/src/rules/vul603_empty_string_test.rs
@@ -10,29 +10,31 @@ use crate::violation::{
 };
 use regex::Regex;
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
+
+/// Matches `=""` or `<>""` patterns.
+static EMPTY_STRING_EQ_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(=|<>)\s*"""#).expect("VUL603 empty string eq regex must compile")
+});
+
+/// Matches `LEN(...)=0` or `LEN(...)>0` patterns.
+static LEN_ZERO_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"LEN\s*\([^)]+\)\s*(=|<>|>|<)\s*0").expect("VUL603 LEN zero regex must compile")
+});
 
 /// Per-sheet cell collection: sheet_index → Vec<(row, col)>.
 type SheetCellMap = Mutex<HashMap<u16, Vec<(u32, u32)>>>;
 
 /// Rule that detects inefficient empty string tests in formulas.
 pub struct EmptyStringTestRule {
-    /// Compiled regex patterns for empty string tests.
-    patterns: Vec<Regex>,
     /// Per-sheet collected cells.
     sheet_cells: SheetCellMap,
 }
 
 impl EmptyStringTestRule {
-    /// Create a new instance with compiled regex.
+    /// Create a new instance.
     pub fn new() -> Self {
         Self {
-            patterns: vec![
-                // ="" or <>"" patterns
-                Regex::new(r#"(=|<>)\s*"""#).unwrap(),
-                // LEN(...)=0 or LEN(...)>0 patterns
-                Regex::new(r"LEN\s*\([^)]+\)\s*(=|<>|>|<)\s*0").unwrap(),
-            ],
             sheet_cells: Mutex::new(HashMap::new()),
         }
     }
@@ -92,7 +94,7 @@ impl WalkerRule for EmptyStringTestRule {
         if let Some(formula) = cell.as_formula() {
             let formula_upper = formula.to_uppercase();
 
-            if self.patterns.iter().any(|p| p.is_match(&formula_upper)) {
+            if EMPTY_STRING_EQ_RE.is_match(&formula_upper) || LEN_ZERO_RE.is_match(&formula_upper) {
                 let mut map = self.sheet_cells.lock().unwrap();
                 map.entry(sheet.sheet_index)
                     .or_default()


### PR DESCRIPTION
## Description

Replace per-instance `Regex` fields with module-level `LazyLock<Regex>` statics across four rules that were compiling regex on every `::new()` call. This eliminates 8 redundant `Regex::new()` calls per rule instantiation cycle (rules are instantiated at least 2× per lint run via `create_all_walker_rules` + `clone_walker_rule`).

## Changes

- **CALC202**: `cell_ref_pattern` field → `static CELL_REF_PATTERN`; struct becomes unit struct
- **CALC201**: `string_regex`, `external_ref_regex`, `number_regex` fields → `static STRING_RE`, `EXTERNAL_REF_RE`, `NUMBER_RE`
- **REF307**: `column_pattern`, `row_pattern` fields → `static COLUMN_PATTERN`, `ROW_PATTERN`
- **VUL603**: `Vec<Regex> patterns` field → `static EMPTY_STRING_EQ_RE`, `LEN_ZERO_RE`
- All initializers use `.expect()` instead of `.unwrap()` for disciplined error context
- No external dependencies — `LazyLock` is `std::sync` (stable since Rust 1.80)

## Testing

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes (27 pre-existing errors in ods/xlsx parsers, none in changed files)
- [x] `cargo fmt --check` passes
- [x] Tested with `tests/minimal_test.xlsx` and `tests/minimal_test.ods` (parity check)

## Changelog

- [x] Added a changelog fragment in `changelog.d/`
  (see [CONTRIBUTING.md](CONTRIBUTING.md#changelog-fragments))
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cosmoscalibur/sheetrs/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->