### PR TITLE
feat: implement must-be rules CALC203, INT401-403, VUL606

### DIFF
--- a/changelog.d/must-be-rules.added.md
+++ b/changelog.d/must-be-rules.added.md
@@ -1,0 +1,9 @@
+Implemented five must-be audit rules:
+
+- **CALC203** (Double Operator): Detects redundant consecutive arithmetic operators in formulas, with configurable double-negative tolerance.
+- **INT401** (Interrupted by Data): Detects value cells breaking a consistent formula sequence.
+- **INT402** (Interrupted by Empty): Detects empty cells breaking a consistent formula sequence.
+- **INT403** (Interrupted by Other): Detects different formulas breaking a consistent formula sequence.
+- **VUL606** (Deprecated Function): Identifies deprecated Excel functions and suggests modern replacements.
+
+The three INT rules share a single data collection pass via `Arc`-backed shared state, avoiding 3× redundant work.

--- a/docs/coding-patterns.md
+++ b/docs/coding-patterns.md
@@ -56,6 +56,44 @@ for single-pass cell-by-cell traversal:
 Violations are reported with full context: File → Sheet → Cell. Use
 `ViolationScope` to specify the granularity.
 
+### Shared-State Groups
+
+When multiple rule IDs share the same collection logic (e.g., INT401–403 all
+scan for formula interruptions), use a **shared-state group** to avoid
+redundant work:
+
+- `new_group()` returns an array of instances sharing a single
+  `Arc<Mutex<...>>` data store. Only the **collector** instance
+  (`is_collector: true`) runs `on_cell()` and `on_sheet_end()`. The collector
+  sets `emit_all_kinds: true` to emit violations for all rule IDs in the group.
+- `new()` returns a **standalone** instance that collects and emits only for
+  its own `kind` (`emit_all_kinds: false`). This is used by `clone_walker_rule`
+  when a single rule needs fresh state.
+
+The group is created in `create_all_walker_rules()` and the standalone path
+is used by `clone_walker_rule()`.
+
+### Formula Normalization
+
+The INT rules normalize formulas to R1C1-style relative offsets so that
+structurally identical formulas in different cells produce the same pattern
+string (e.g., `=A1+B1` in cell C1 and `=A2+B2` in cell C2 both become
+`=R[0]C[-2]+R[0]C[-1]`).
+
+Absolute references (`$A$1`) are normalized to fixed markers (`R0C0`) to
+distinguish them from relative references. The regex skips false matches
+on function names (e.g., `LOG10`) and sheet qualifiers (e.g., `SHEET1!`)
+by checking surrounding context.
+
+### Configuration Parameters
+
+Rules may accept configuration parameters via `LinterConfig`:
+
+- `calc203_allow_double_negative` (bool) — If `true`, `--` (double negative /
+  coercion to number) is not flagged by CALC203.
+- `int_min_formula_sequence` (int, default 3) — Minimum formula run length
+  for INT401–403 to consider a sequence.
+
 ## Performance Guidelines
 
 - Use streaming readers — avoid loading data that is not needed.

--- a/docs/coding-patterns.md
+++ b/docs/coding-patterns.md
@@ -66,12 +66,11 @@ redundant work:
   `Arc<Mutex<...>>` data store. Only the **collector** instance
   (`is_collector: true`) runs `on_cell()` and `on_sheet_end()`. The collector
   sets `emit_all_kinds: true` to emit violations for all rule IDs in the group.
-- `new()` returns a **standalone** instance that collects and emits only for
-  its own `kind` (`emit_all_kinds: false`). This is used by `clone_walker_rule`
-  when a single rule needs fresh state.
 
-The group is created in `create_all_walker_rules()` and the standalone path
-is used by `clone_walker_rule()`.
+Both `create_all_walker_rules()` and `clone_walker_rule()` use `new_group()`
+to create INT instances. `clone_walker_rule()` returns `Vec<Box<dyn WalkerRule>>`
+so it can return the full group; `lint_workbook` deduplicates by rule ID to
+prevent triplication when all three INT rules are enabled.
 
 ### Formula Normalization
 

--- a/docs/coding-patterns.md
+++ b/docs/coding-patterns.md
@@ -84,6 +84,26 @@ distinguish them from relative references. The regex skips false matches
 on function names (e.g., `LOG10`) and sheet qualifiers (e.g., `SHEET1!`)
 by checking surrounding context.
 
+### Gap Policy (Interruption Context Boundaries)
+
+When scanning for interruptions, `find_interruptions` must decide how far
+apart two matching formulas can be and still belong to the same "run". The
+algorithm uses a **gap=1 policy**:
+
+- **1 absent cell** between formula cells → bridged as an Empty interruption
+  (likely an oversight: missing formula, formatting artifact).
+- **2+ absent cells** → the run is broken. The two formula blocks are treated
+  as **separate contexts** (headers, spacing, different data sections).
+
+This is a conservative choice that avoids merging unrelated formula regions.
+A spreadsheet column often contains multiple independent formula contexts
+separated by blank rows. Merging them would produce false "Interrupted by
+Other/Empty" violations.
+
+**Performance:** The gap=1 policy makes the algorithm strictly O(n) in the
+number of cells. No range iteration is needed — only a single position check
+(`pos == run_end + 2`) per cell transition.
+
 ### Configuration Parameters
 
 Rules may accept configuration parameters via `LinterConfig`:

--- a/sheetrs/src/lib.rs
+++ b/sheetrs/src/lib.rs
@@ -62,11 +62,15 @@ impl Linter {
     pub fn lint_workbook(&self, workbook: &reader::Workbook) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
 
-        // Run walker rules in single pass
+        // Run walker rules in single pass.
+        // clone_walker_rule may return multiple rules (e.g. INT group returns 3).
+        // Deduplicate by rule ID to avoid 3× INT rules when all 3 are enabled.
+        let mut seen_ids = std::collections::HashSet::new();
         let walker_rules_cloned: Vec<Box<dyn WalkerRule>> = self
             .walker_rules
             .iter()
-            .map(|r| rules::registry::clone_walker_rule(r.as_ref(), &self.config))
+            .flat_map(|r| rules::registry::clone_walker_rule(r.as_ref(), &self.config))
+            .filter(|r| seen_ids.insert(r.id()))
             .collect();
         let walker = WorkbookWalker::new(workbook, walker_rules_cloned);
         let walker_violations = walker.walk();

--- a/sheetrs/src/rules/calc203_double_operator.rs
+++ b/sheetrs/src/rules/calc203_double_operator.rs
@@ -2,11 +2,60 @@
 //!
 //! Description: Flags redundant operator sequences (e.g., "++", "--") indicating potential typos.
 
-use super::{RuleCategory, WalkerRule};
-use crate::violation::RuleId;
+use super::{LinterContext, RuleCategory, WalkerRule};
+use crate::config::LinterConfig;
+use crate::reader::{Cell, Sheet};
+use crate::violation::{
+    CellReference, FormatContext, RuleId, Severity, Violation, ViolationData, ViolationScope,
+};
+use regex::Regex;
+use std::sync::LazyLock;
 
-/// Rule that identifies double operators in formulas
-pub struct DoubleOperatorRule;
+/// Regex matching truly redundant consecutive arithmetic operators.
+/// Matches pairs like `++`, `--`, `+-`, `-+`, `**`, `//`, `^^`, `*/`, `/*`, etc.
+/// Excludes valid unary +/- after binary operators `*`, `/`, `^` (e.g. `A1*-B1`).
+static DOUBLE_OP_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[+\-]\s*[+\-*/^]|[*/^]\s*[*/^]").unwrap());
+
+/// Regex for stripping string literals from formulas to avoid false positives.
+static STRING_LITERAL_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#""[^"]*""#).unwrap());
+
+/// Rule that identifies double operators in formulas.
+pub struct DoubleOperatorRule {
+    /// Whether to allow `--` as intentional double-negative coercion.
+    allow_double_negative: bool,
+}
+
+impl DoubleOperatorRule {
+    /// Create a new instance with configuration.
+    pub fn new(config: &LinterConfig) -> Self {
+        Self {
+            allow_double_negative: config
+                .get_param_bool("calc203_allow_double_negative", None)
+                .unwrap_or(false),
+        }
+    }
+}
+
+/// Incident data for CALC203.
+#[derive(Debug)]
+pub struct DoubleOperatorData {
+    /// The matched operator pair (e.g., "++", "--").
+    pub matched_ops: String,
+}
+
+impl ViolationData for DoubleOperatorData {
+    fn format_message(&self, _ctx: &FormatContext<'_>) -> String {
+        format!(
+            "Double operator \"{}\" found in formula. This may indicate a typo.",
+            self.matched_ops
+        )
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
 
 impl WalkerRule for DoubleOperatorRule {
     fn id(&self) -> RuleId {
@@ -19,5 +68,197 @@ impl WalkerRule for DoubleOperatorRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Calculations
+    }
+
+    fn on_cell(&self, sheet: &Sheet, cell: &Cell, _ctx: &mut LinterContext) -> Vec<Violation> {
+        let formula = match cell.as_formula() {
+            Some(f) => f,
+            None => return Vec::new(),
+        };
+
+        // Strip string literals to avoid false positives in text constants
+        let cleaned = STRING_LITERAL_RE.replace_all(formula, "");
+
+        let mut violations = Vec::new();
+
+        for m in DOUBLE_OP_RE.find_iter(&cleaned) {
+            let matched = m.as_str();
+            // Extract just the operator characters (strip whitespace)
+            let ops: String = matched.chars().filter(|c| !c.is_whitespace()).collect();
+
+            // Skip `--` if allow_double_negative is enabled
+            if self.allow_double_negative && ops == "--" {
+                continue;
+            }
+
+            violations.push(Violation::with_data(
+                RuleId::Calc203,
+                ViolationScope::Cell(sheet.sheet_index, CellReference::new(cell.row, cell.col)),
+                DoubleOperatorData { matched_ops: ops },
+                Severity::Warning,
+            ));
+            // One violation per cell is sufficient
+            break;
+        }
+
+        violations
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reader::workbook::{Cell, CellValue, Sheet};
+    use std::collections::HashMap;
+
+    fn make_formula_cell(row: u32, col: u32, formula: &str) -> Cell {
+        Cell {
+            formula: Some(<Box<str>>::from(formula)),
+            num_fmt: None,
+            row,
+            col,
+            value: CellValue::Empty,
+        }
+    }
+
+    fn make_sheet(cells: Vec<Cell>) -> Sheet {
+        let mut cell_map = HashMap::new();
+        for cell in cells {
+            cell_map.insert((cell.row, cell.col), cell);
+        }
+        Sheet {
+            name: "Sheet1".to_string(),
+            sheet_index: 0,
+            cells: cell_map,
+            ..Default::default()
+        }
+    }
+
+    fn run_rule(rule: &DoubleOperatorRule, sheet: &Sheet) -> Vec<Violation> {
+        let mut ctx = LinterContext::default();
+        let mut violations = Vec::new();
+        for cell in sheet.all_cells() {
+            violations.extend(rule.on_cell(sheet, cell, &mut ctx));
+        }
+        violations
+    }
+
+    #[test]
+    fn test_double_plus() {
+        let config = LinterConfig::default();
+        let rule = DoubleOperatorRule::new(&config);
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "A1++B1")]);
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].rule_id, RuleId::Calc203);
+        let data = violations[0].data::<DoubleOperatorData>().unwrap();
+        assert_eq!(data.matched_ops, "++");
+    }
+
+    #[test]
+    fn test_double_minus() {
+        let config = LinterConfig::default();
+        let rule = DoubleOperatorRule::new(&config);
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "A1--B1")]);
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_double_minus_allowed() {
+        let mut config = LinterConfig::default();
+        config.global.params.insert(
+            "calc203_allow_double_negative".to_string(),
+            toml::Value::Boolean(true),
+        );
+        let rule = DoubleOperatorRule::new(&config);
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "SUMPRODUCT(--(A1:A10>5))")]);
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_operators_with_whitespace() {
+        let config = LinterConfig::default();
+        let rule = DoubleOperatorRule::new(&config);
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "A1 + + B1")]);
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_string_literal_not_flagged() {
+        let config = LinterConfig::default();
+        let rule = DoubleOperatorRule::new(&config);
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "CONCAT(\"++\", A1)")]);
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_single_operator_ok() {
+        let config = LinterConfig::default();
+        let rule = DoubleOperatorRule::new(&config);
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "A1+B1")]);
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_star_slash() {
+        let config = LinterConfig::default();
+        let rule = DoubleOperatorRule::new(&config);
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "A1*/B1")]);
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 1);
+        let data = violations[0].data::<DoubleOperatorData>().unwrap();
+        assert_eq!(data.matched_ops, "*/");
+    }
+
+    #[test]
+    fn test_unary_minus_ok() {
+        let config = LinterConfig::default();
+        let rule = DoubleOperatorRule::new(&config);
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "-A1")]);
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_multiply_by_negative_ok() {
+        let config = LinterConfig::default();
+        let rule = DoubleOperatorRule::new(&config);
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "A1*-B1")]);
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_divide_by_negative_ok() {
+        let config = LinterConfig::default();
+        let rule = DoubleOperatorRule::new(&config);
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "A1/-1")]);
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_power_of_negative_ok() {
+        let config = LinterConfig::default();
+        let rule = DoubleOperatorRule::new(&config);
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "A1^-2")]);
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 0);
     }
 }

--- a/sheetrs/src/rules/int401_interrupted_by_data.rs
+++ b/sheetrs/src/rules/int401_interrupted_by_data.rs
@@ -71,13 +71,17 @@ pub struct InterruptionRule {
     min_formula_sequence: usize,
     /// Per-sheet collected cell classifications (shared across instances in a group).
     sheet_data: Arc<SheetCellData>,
-    /// Whether this instance is the "collector" that gathers cell data and emits
-    /// violations for all kinds. Only one instance per group should be the collector.
+    /// Whether this instance is the "collector" that gathers cell data.
+    /// Only one instance per group should be the collector.
     is_collector: bool,
+    /// Whether this collector should emit violations for all kinds (group mode)
+    /// or only for `self.kind` (standalone mode from `clone_walker_rule`).
+    emit_all_kinds: bool,
 }
 
 impl InterruptionRule {
     /// Create a standalone instance (used by `clone_walker_rule`).
+    /// Standalone instances collect data and emit violations only for their own kind.
     pub fn new(kind: InterruptionKind, config: &LinterConfig) -> Self {
         let min_seq = config
             .get_param_int("int_min_formula_sequence", None)
@@ -87,6 +91,7 @@ impl InterruptionRule {
             min_formula_sequence: min_seq,
             sheet_data: Arc::new(Mutex::new(HashMap::new())),
             is_collector: true,
+            emit_all_kinds: false,
         }
     }
 
@@ -103,31 +108,56 @@ impl InterruptionRule {
                 min_formula_sequence: min_seq,
                 sheet_data: Arc::clone(&shared),
                 is_collector: true,
+                emit_all_kinds: true,
             },
             Self {
                 kind: InterruptionKind::Empty,
                 min_formula_sequence: min_seq,
                 sheet_data: Arc::clone(&shared),
                 is_collector: false,
+                emit_all_kinds: false,
             },
             Self {
                 kind: InterruptionKind::Other,
                 min_formula_sequence: min_seq,
                 sheet_data: Arc::clone(&shared),
                 is_collector: false,
+                emit_all_kinds: false,
             },
         ]
     }
 
     /// Normalize a formula by converting cell references to R1C1-style offsets.
     /// Relative references become relative offsets; absolute ($) references stay absolute.
+    /// Skips false matches on function names (e.g. LOG10) and sheet qualifiers (e.g. SHEET1!).
     pub(crate) fn normalize_formula(formula: &str, cell_row: u32, cell_col: u32) -> String {
-        // Use a regex that captures the dollar signs to detect absolute refs
+        // Match cell references: optional $ + 1-3 uppercase letters + optional $ + digits.
+        // The {1,3} limit matches valid Excel columns (A–XFD).
         static ABS_REF_RE: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"(\$?)([A-Z]+)(\$?)([0-9]+)").unwrap());
+            LazyLock::new(|| Regex::new(r"(\$?)([A-Z]{1,3})(\$?)([0-9]+)").unwrap());
+
+        let formula_bytes = formula.as_bytes();
 
         ABS_REF_RE
             .replace_all(formula, |caps: &regex::Captures| {
+                let m = caps.get(0).unwrap();
+
+                // Skip if preceded by a letter — part of a function or sheet name
+                // (e.g. LOG10 → LOG is preceded by nothing but "10" is the row part;
+                //  the full match LOG10 would be LOG as col + 10 as row)
+                if m.start() > 0 && formula_bytes[m.start() - 1].is_ascii_alphabetic() {
+                    return m.as_str().to_string();
+                }
+
+                // Skip if followed by ! (sheet qualifier, e.g. S1!A1 → skip S1)
+                // or ( (function call, e.g. IF(...) — unlikely with {1,3} but safe)
+                if m.end() < formula_bytes.len() {
+                    let next = formula_bytes[m.end()];
+                    if next == b'!' || next == b'(' {
+                        return m.as_str().to_string();
+                    }
+                }
+
                 let col_abs = &caps[1] == "$";
                 let col_str = &caps[2];
                 let row_abs = &caps[3] == "$";
@@ -393,6 +423,10 @@ impl WalkerRule for InterruptionRule {
             col_cells.sort_by_key(|(row, _)| *row);
             let ints = Self::find_interruptions(&col_cells, true, col, self.min_formula_sequence);
             for int in ints {
+                // In standalone mode, only emit violations matching self.kind
+                if !self.emit_all_kinds && int.kind != self.kind {
+                    continue;
+                }
                 violations.push(Violation::with_data(
                     rule_id_for(int.kind),
                     ViolationScope::Cell(sheet.sheet_index, CellReference::new(int.row, int.col)),
@@ -417,6 +451,10 @@ impl WalkerRule for InterruptionRule {
             row_cells.sort_by_key(|(col, _)| *col);
             let ints = Self::find_interruptions(&row_cells, false, row, self.min_formula_sequence);
             for int in ints {
+                // In standalone mode, only emit violations matching self.kind
+                if !self.emit_all_kinds && int.kind != self.kind {
+                    continue;
+                }
                 violations.push(Violation::with_data(
                     rule_id_for(int.kind),
                     ViolationScope::Cell(sheet.sheet_index, CellReference::new(int.row, int.col)),

--- a/sheetrs/src/rules/int401_interrupted_by_data.rs
+++ b/sheetrs/src/rules/int401_interrupted_by_data.rs
@@ -186,6 +186,10 @@ impl InterruptionRule {
     }
 
     /// Scan a sequence of cells along one axis and find interruptions.
+    ///
+    /// The algorithm iterates over actual cells (O(n)), using a HashMap for
+    /// O(1) position lookups. A max-gap limit prevents degenerate behaviour
+    /// on extremely sparse data.
     fn find_interruptions(
         cells: &[(u32, CellType)],
         is_column: bool,
@@ -198,71 +202,81 @@ impl InterruptionRule {
 
         let mut interruptions = Vec::new();
 
-        // Build the full position range from min to max
-        let min_pos = cells.iter().map(|(pos, _)| *pos).min().unwrap_or(0);
-        let max_pos = cells.iter().map(|(pos, _)| *pos).max().unwrap_or(0);
-
-        // Create a lookup from position to cell type
+        // O(1) lookup from position → cell type
         let cell_map: HashMap<u32, &CellType> = cells.iter().map(|(pos, ct)| (*pos, ct)).collect();
+
+        // Maximum gap (absent positions) to bridge between matching formulas.
+        // Beyond this, we consider the run broken. This caps worst-case iteration
+        // for sparse data (e.g. rows 1 and 1_000_000) to O(MAX_GAP) per bridge.
+        const MAX_GAP: u32 = 100;
 
         /// Classify a position from the cell_map (absent = Empty).
         fn classify<'a>(cell_map: &'a HashMap<u32, &'a CellType>, pos: u32) -> &'a CellType {
             cell_map.get(&pos).copied().unwrap_or(&CellType::Empty)
         }
 
-        /// Scan forward from `start` (exclusive) up to `max` (inclusive) looking
-        /// for the next formula cell matching `pattern`. Returns its position
-        /// and a vec of (position, InterruptionKind) for cells in between.
-        fn scan_for_next_match(
-            cell_map: &HashMap<u32, &CellType>,
-            start: u32,
-            max: u32,
-            pattern: &str,
-        ) -> Option<(u32, Vec<(u32, InterruptionKind)>)> {
-            let mut gaps = Vec::new();
-            let mut probe = start + 1;
-            while probe <= max {
-                match classify(cell_map, probe) {
-                    CellType::Formula(p) if p == pattern => return Some((probe, gaps)),
-                    CellType::Formula(_) => gaps.push((probe, InterruptionKind::Other)),
-                    CellType::Value => gaps.push((probe, InterruptionKind::Data)),
-                    CellType::Empty => gaps.push((probe, InterruptionKind::Empty)),
-                }
-                probe += 1;
-            }
-            None
-        }
-
-        // Walk through all positions and find formula runs
-        let mut pos = min_pos;
-        while pos <= max_pos {
-            // Skip non-formula cells to find the start of a potential formula run
-            let pattern = match classify(&cell_map, pos) {
+        // Walk through sorted cells, building formula runs.
+        let mut i = 0;
+        while i < cells.len() {
+            // Find the start of a formula run
+            let pattern = match &cells[i].1 {
                 CellType::Formula(p) => p.clone(),
                 _ => {
-                    pos += 1;
+                    i += 1;
                     continue;
                 }
             };
 
-            let run_start = pos;
-            let mut run_end = pos;
+            let run_start = cells[i].0;
+            let mut run_end = run_start;
             let mut run_interruptions: Vec<(u32, InterruptionKind)> = Vec::new();
 
-            // Extend the run, collecting interruptions along the way.
-            // scan_for_next_match bridges multi-cell gaps (C3/C4 fix).
-            let mut scan_pos = pos;
-            while let Some((next_match, gap_interruptions)) =
-                scan_for_next_match(&cell_map, scan_pos, max_pos, &pattern)
-            {
-                run_interruptions.extend(gap_interruptions);
-                run_end = next_match;
-                scan_pos = next_match;
+            // Extend the run by scanning forward through cells.
+            let mut j = i + 1;
+            while j < cells.len() {
+                let (pos, ct) = &cells[j];
+
+                // If this cell is far beyond run_end, check the gap
+                if *pos > run_end + 1 {
+                    let gap = *pos - run_end - 1;
+                    if gap > MAX_GAP {
+                        // Too sparse — break the run
+                        break;
+                    }
+                    // Record absent positions as Empty interruptions
+                    for gap_pos in (run_end + 1)..*pos {
+                        if !cell_map.contains_key(&gap_pos) {
+                            run_interruptions.push((gap_pos, InterruptionKind::Empty));
+                        }
+                    }
+                }
+
+                match ct {
+                    CellType::Formula(p) if p == &pattern => {
+                        run_end = *pos;
+                        j += 1;
+                    }
+                    CellType::Formula(_) => {
+                        run_interruptions.push((*pos, InterruptionKind::Other));
+                        run_end = *pos;
+                        j += 1;
+                    }
+                    CellType::Value => {
+                        run_interruptions.push((*pos, InterruptionKind::Data));
+                        run_end = *pos;
+                        j += 1;
+                    }
+                    CellType::Empty => {
+                        run_interruptions.push((*pos, InterruptionKind::Empty));
+                        run_end = *pos;
+                        j += 1;
+                    }
+                }
             }
 
             // For each interruption, check that at least one side has ≥ min_seq
-            // consecutive formulas with the same pattern.
-            for (int_pos, int_kind) in run_interruptions {
+            // consecutive matching formulas.
+            for &(int_pos, int_kind) in &run_interruptions {
                 // Count formulas before the interruption
                 let mut before_count = 0usize;
                 let mut check = int_pos;
@@ -303,7 +317,8 @@ impl InterruptionRule {
                 }
             }
 
-            pos = run_end + 1;
+            // Advance past this run
+            i = if j > i { j } else { i + 1 };
         }
 
         interruptions

--- a/sheetrs/src/rules/int401_interrupted_by_data.rs
+++ b/sheetrs/src/rules/int401_interrupted_by_data.rs
@@ -1,23 +1,698 @@
-//! INT401: Interrupted by Data detection
+//! INT401–403: Formula Interruption detection
 //!
-//! Description: Detects data entries that break a consistent formula pattern in a row or column.
+//! Description: Detects cells that break a consistent formula pattern in a row or column.
+//! - INT401: Interrupted by data (value cell breaks a formula sequence)
+//! - INT402: Interrupted by empty cell
+//! - INT403: Interrupted by a different formula pattern
+//!
+//! All three rules share a single `InterruptionRule` struct parameterized by
+//! `InterruptionKind`. A single `on_cell()` pass collects cell classification data,
+//! and `on_sheet_end()` emits violations for all three kinds simultaneously.
 
-use super::{RuleCategory, WalkerRule};
-use crate::violation::RuleId;
+use super::{LinterContext, RuleCategory, WalkerRule};
+use crate::config::LinterConfig;
+use crate::reader::{Cell, Sheet};
+use crate::violation::{
+    CellReference, FormatContext, RuleId, Severity, Violation, ViolationData, ViolationScope,
+};
+use regex::Regex;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
 
-/// Rule that identifies formulas interrupted by raw data
-pub struct InterruptedByDataRule;
+/// Which type of interruption this rule instance detects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InterruptionKind {
+    /// INT401: formula sequence interrupted by a data (value) cell.
+    Data,
+    /// INT402: formula sequence interrupted by an empty cell.
+    Empty,
+    /// INT403: formula sequence interrupted by a different formula pattern.
+    Other,
+}
 
-impl WalkerRule for InterruptedByDataRule {
+/// Classification of a cell for interruption analysis.
+#[derive(Debug, Clone)]
+enum CellType {
+    /// Cell has a formula with the given normalized pattern.
+    Formula(String),
+    /// Cell has a value but no formula.
+    Value,
+    /// Cell is empty (no value, no formula).
+    Empty,
+}
+
+/// Per-sheet collected cell data: sheet_index → Vec<(row, col, CellType)>.
+type SheetCellData = Mutex<HashMap<u16, Vec<(u32, u32, CellType)>>>;
+
+/// An interruption detected during sequence scanning.
+#[derive(Debug)]
+struct Interruption {
+    /// Row of the interrupting cell.
+    row: u32,
+    /// Column of the interrupting cell.
+    col: u32,
+    /// Kind of interruption.
+    kind: InterruptionKind,
+    /// Whether the interruption is in a column (true) or row (false).
+    is_column: bool,
+    /// The axis index (column index if is_column, row index if !is_column).
+    axis_index: u32,
+    /// Start of the formula sequence (row if column, col if row).
+    seq_start: u32,
+    /// End of the formula sequence (row if column, col if row).
+    seq_end: u32,
+}
+
+/// Rule that detects formula interruptions.
+pub struct InterruptionRule {
+    /// Which kind of interruption this instance reports.
+    kind: InterruptionKind,
+    /// Minimum number of formula cells for a sequence to be considered.
+    min_formula_sequence: usize,
+    /// Per-sheet collected cell classifications (shared across instances in a group).
+    sheet_data: Arc<SheetCellData>,
+    /// Whether this instance is the "collector" that gathers cell data and emits
+    /// violations for all kinds. Only one instance per group should be the collector.
+    is_collector: bool,
+}
+
+impl InterruptionRule {
+    /// Create a standalone instance (used by `clone_walker_rule`).
+    pub fn new(kind: InterruptionKind, config: &LinterConfig) -> Self {
+        let min_seq = config
+            .get_param_int("int_min_formula_sequence", None)
+            .unwrap_or(3) as usize;
+        Self {
+            kind,
+            min_formula_sequence: min_seq,
+            sheet_data: Arc::new(Mutex::new(HashMap::new())),
+            is_collector: true,
+        }
+    }
+
+    /// Create a group of 3 instances sharing a single data store.
+    /// Only the first (Data) instance collects data and emits all violations.
+    pub fn new_group(config: &LinterConfig) -> [Self; 3] {
+        let min_seq = config
+            .get_param_int("int_min_formula_sequence", None)
+            .unwrap_or(3) as usize;
+        let shared = Arc::new(Mutex::new(HashMap::new()));
+        [
+            Self {
+                kind: InterruptionKind::Data,
+                min_formula_sequence: min_seq,
+                sheet_data: Arc::clone(&shared),
+                is_collector: true,
+            },
+            Self {
+                kind: InterruptionKind::Empty,
+                min_formula_sequence: min_seq,
+                sheet_data: Arc::clone(&shared),
+                is_collector: false,
+            },
+            Self {
+                kind: InterruptionKind::Other,
+                min_formula_sequence: min_seq,
+                sheet_data: Arc::clone(&shared),
+                is_collector: false,
+            },
+        ]
+    }
+
+    /// Normalize a formula by converting cell references to R1C1-style offsets.
+    /// Relative references become relative offsets; absolute ($) references stay absolute.
+    pub(crate) fn normalize_formula(formula: &str, cell_row: u32, cell_col: u32) -> String {
+        // Use a regex that captures the dollar signs to detect absolute refs
+        static ABS_REF_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"(\$?)([A-Z]+)(\$?)([0-9]+)").unwrap());
+
+        ABS_REF_RE
+            .replace_all(formula, |caps: &regex::Captures| {
+                let col_abs = &caps[1] == "$";
+                let col_str = &caps[2];
+                let row_abs = &caps[3] == "$";
+                let row_str = &caps[4];
+
+                let ref_col = col_str
+                    .chars()
+                    .fold(0i64, |acc, c| acc * 26 + (c as i64 - 'A' as i64 + 1))
+                    - 1;
+                let ref_row = row_str.parse::<i64>().unwrap_or(1) - 1;
+
+                let row_part = if row_abs {
+                    format!("R{}", ref_row)
+                } else {
+                    format!("R[{}]", ref_row - cell_row as i64)
+                };
+                let col_part = if col_abs {
+                    format!("C{}", ref_col)
+                } else {
+                    format!("C[{}]", ref_col - cell_col as i64)
+                };
+
+                format!("{}{}", row_part, col_part)
+            })
+            .to_string()
+    }
+
+    /// Scan a sequence of cells along one axis and find interruptions.
+    fn find_interruptions(
+        cells: &[(u32, CellType)],
+        is_column: bool,
+        axis_index: u32,
+        min_seq: usize,
+    ) -> Vec<Interruption> {
+        if cells.len() < min_seq {
+            return Vec::new();
+        }
+
+        let mut interruptions = Vec::new();
+
+        // Build the full position range from min to max
+        let min_pos = cells.iter().map(|(pos, _)| *pos).min().unwrap_or(0);
+        let max_pos = cells.iter().map(|(pos, _)| *pos).max().unwrap_or(0);
+
+        // Create a lookup from position to cell type
+        let cell_map: HashMap<u32, &CellType> = cells.iter().map(|(pos, ct)| (*pos, ct)).collect();
+
+        /// Classify a position from the cell_map (absent = Empty).
+        fn classify<'a>(cell_map: &'a HashMap<u32, &'a CellType>, pos: u32) -> &'a CellType {
+            cell_map.get(&pos).copied().unwrap_or(&CellType::Empty)
+        }
+
+        /// Scan forward from `start` (exclusive) up to `max` (inclusive) looking
+        /// for the next formula cell matching `pattern`. Returns its position
+        /// and a vec of (position, InterruptionKind) for cells in between.
+        fn scan_for_next_match(
+            cell_map: &HashMap<u32, &CellType>,
+            start: u32,
+            max: u32,
+            pattern: &str,
+        ) -> Option<(u32, Vec<(u32, InterruptionKind)>)> {
+            let mut gaps = Vec::new();
+            let mut probe = start + 1;
+            while probe <= max {
+                match classify(cell_map, probe) {
+                    CellType::Formula(p) if p == pattern => return Some((probe, gaps)),
+                    CellType::Formula(_) => gaps.push((probe, InterruptionKind::Other)),
+                    CellType::Value => gaps.push((probe, InterruptionKind::Data)),
+                    CellType::Empty => gaps.push((probe, InterruptionKind::Empty)),
+                }
+                probe += 1;
+            }
+            None
+        }
+
+        // Walk through all positions and find formula runs
+        let mut pos = min_pos;
+        while pos <= max_pos {
+            // Skip non-formula cells to find the start of a potential formula run
+            let pattern = match classify(&cell_map, pos) {
+                CellType::Formula(p) => p.clone(),
+                _ => {
+                    pos += 1;
+                    continue;
+                }
+            };
+
+            let run_start = pos;
+            let mut run_end = pos;
+            let mut run_interruptions: Vec<(u32, InterruptionKind)> = Vec::new();
+
+            // Extend the run, collecting interruptions along the way.
+            // scan_for_next_match bridges multi-cell gaps (C3/C4 fix).
+            let mut scan_pos = pos;
+            while let Some((next_match, gap_interruptions)) =
+                scan_for_next_match(&cell_map, scan_pos, max_pos, &pattern)
+            {
+                run_interruptions.extend(gap_interruptions);
+                run_end = next_match;
+                scan_pos = next_match;
+            }
+
+            // For each interruption, check that at least one side has ≥ min_seq
+            // consecutive formulas with the same pattern.
+            for (int_pos, int_kind) in run_interruptions {
+                // Count formulas before the interruption
+                let mut before_count = 0usize;
+                let mut check = int_pos;
+                while check > run_start {
+                    check -= 1;
+                    match classify(&cell_map, check) {
+                        CellType::Formula(p) if p == &pattern => before_count += 1,
+                        _ => break,
+                    }
+                }
+
+                // Count formulas after the interruption
+                let mut after_count = 0usize;
+                check = int_pos + 1;
+                while check <= run_end {
+                    match classify(&cell_map, check) {
+                        CellType::Formula(p) if p == &pattern => after_count += 1,
+                        _ => break,
+                    }
+                    check += 1;
+                }
+
+                if before_count >= min_seq || after_count >= min_seq {
+                    let (row, col) = if is_column {
+                        (int_pos, axis_index)
+                    } else {
+                        (axis_index, int_pos)
+                    };
+                    interruptions.push(Interruption {
+                        row,
+                        col,
+                        kind: int_kind,
+                        is_column,
+                        axis_index,
+                        seq_start: run_start,
+                        seq_end: run_end,
+                    });
+                }
+            }
+
+            pos = run_end + 1;
+        }
+
+        interruptions
+    }
+}
+
+/// Incident data for INT401–403.
+#[derive(Debug)]
+pub struct InterruptionData {
+    /// Kind of interruption.
+    pub kind: InterruptionKind,
+    /// Whether the interruption is in a column (true) or row (false).
+    pub is_column: bool,
+    /// The axis index (column for vertical, row for horizontal).
+    pub axis_index: u32,
+    /// Start of the formula sequence.
+    pub seq_start: u32,
+    /// End of the formula sequence.
+    pub seq_end: u32,
+}
+
+impl ViolationData for InterruptionData {
+    fn format_message(&self, _ctx: &FormatContext<'_>) -> String {
+        let kind_label = match self.kind {
+            InterruptionKind::Data => "Value cell",
+            InterruptionKind::Empty => "Empty cell",
+            InterruptionKind::Other => "Different formula",
+        };
+        let axis_label = if self.is_column {
+            format!("column {}", CellReference::col_to_letter(self.axis_index))
+        } else {
+            format!("row {}", self.axis_index + 1)
+        };
+        format!(
+            "{} interrupts a formula sequence in {} (positions {}–{}).",
+            kind_label,
+            axis_label,
+            self.seq_start + 1,
+            self.seq_end + 1,
+        )
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl WalkerRule for InterruptionRule {
     fn id(&self) -> RuleId {
-        RuleId::Int401
+        match self.kind {
+            InterruptionKind::Data => RuleId::Int401,
+            InterruptionKind::Empty => RuleId::Int402,
+            InterruptionKind::Other => RuleId::Int403,
+        }
     }
 
     fn name(&self) -> &str {
-        "Interrupted by Data"
+        match self.kind {
+            InterruptionKind::Data => "Interrupted by Data",
+            InterruptionKind::Empty => "Interrupted by Empty",
+            InterruptionKind::Other => "Interrupted by Other",
+        }
     }
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Interruptions
+    }
+
+    fn on_cell(&self, sheet: &Sheet, cell: &Cell, _ctx: &mut LinterContext) -> Vec<Violation> {
+        if !self.is_collector {
+            return Vec::new();
+        }
+
+        let cell_type = if let Some(formula) = cell.as_formula() {
+            let normalized = Self::normalize_formula(&formula.to_uppercase(), cell.row, cell.col);
+            CellType::Formula(normalized)
+        } else if cell.value.is_empty() {
+            CellType::Empty
+        } else {
+            CellType::Value
+        };
+
+        let mut map = self.sheet_data.lock().unwrap();
+        map.entry(sheet.sheet_index)
+            .or_default()
+            .push((cell.row, cell.col, cell_type));
+
+        Vec::new()
+    }
+
+    fn on_sheet_end(&self, sheet: &Sheet, _ctx: &mut LinterContext) -> Vec<Violation> {
+        if !self.is_collector {
+            return Vec::new();
+        }
+
+        let mut map = self.sheet_data.lock().unwrap();
+        let cells = match map.remove(&sheet.sheet_index) {
+            Some(c) => c,
+            None => return Vec::new(),
+        };
+
+        let mut violations = Vec::new();
+
+        // Helper to map InterruptionKind → RuleId
+        let rule_id_for = |kind: InterruptionKind| match kind {
+            InterruptionKind::Data => RuleId::Int401,
+            InterruptionKind::Empty => RuleId::Int402,
+            InterruptionKind::Other => RuleId::Int403,
+        };
+
+        // Group by column → scan vertically
+        let mut by_col: HashMap<u32, Vec<(u32, CellType)>> = HashMap::new();
+        for (row, col, ct) in &cells {
+            by_col.entry(*col).or_default().push((*row, ct.clone()));
+        }
+        for (col, mut col_cells) in by_col {
+            col_cells.sort_by_key(|(row, _)| *row);
+            let ints = Self::find_interruptions(&col_cells, true, col, self.min_formula_sequence);
+            for int in ints {
+                violations.push(Violation::with_data(
+                    rule_id_for(int.kind),
+                    ViolationScope::Cell(sheet.sheet_index, CellReference::new(int.row, int.col)),
+                    InterruptionData {
+                        kind: int.kind,
+                        is_column: int.is_column,
+                        axis_index: int.axis_index,
+                        seq_start: int.seq_start,
+                        seq_end: int.seq_end,
+                    },
+                    Severity::Warning,
+                ));
+            }
+        }
+
+        // Group by row → scan horizontally
+        let mut by_row: HashMap<u32, Vec<(u32, CellType)>> = HashMap::new();
+        for (row, col, ct) in &cells {
+            by_row.entry(*row).or_default().push((*col, ct.clone()));
+        }
+        for (row, mut row_cells) in by_row {
+            row_cells.sort_by_key(|(col, _)| *col);
+            let ints = Self::find_interruptions(&row_cells, false, row, self.min_formula_sequence);
+            for int in ints {
+                violations.push(Violation::with_data(
+                    rule_id_for(int.kind),
+                    ViolationScope::Cell(sheet.sheet_index, CellReference::new(int.row, int.col)),
+                    InterruptionData {
+                        kind: int.kind,
+                        is_column: int.is_column,
+                        axis_index: int.axis_index,
+                        seq_start: int.seq_start,
+                        seq_end: int.seq_end,
+                    },
+                    Severity::Warning,
+                ));
+            }
+        }
+
+        violations
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reader::workbook::{Cell, CellValue, Sheet};
+    use std::collections::HashMap;
+
+    fn make_formula_cell(row: u32, col: u32, formula: &str) -> Cell {
+        Cell {
+            formula: Some(<Box<str>>::from(formula)),
+            num_fmt: None,
+            row,
+            col,
+            value: CellValue::Empty,
+        }
+    }
+
+    fn make_value_cell(row: u32, col: u32, value: f64) -> Cell {
+        Cell {
+            formula: None,
+            num_fmt: None,
+            row,
+            col,
+            value: CellValue::Number(value),
+        }
+    }
+
+    fn make_sheet(cells: Vec<Cell>) -> Sheet {
+        let mut cell_map = HashMap::new();
+        for cell in cells {
+            cell_map.insert((cell.row, cell.col), cell);
+        }
+        Sheet {
+            name: "Sheet1".to_string(),
+            sheet_index: 0,
+            cells: cell_map,
+            ..Default::default()
+        }
+    }
+
+    fn run_rule(kind: InterruptionKind, sheet: &Sheet) -> Vec<Violation> {
+        let config = LinterConfig::default();
+        let rule = InterruptionRule::new(kind, &config);
+        let mut ctx = LinterContext::default();
+        for cell in sheet.all_cells() {
+            rule.on_cell(sheet, cell, &mut ctx);
+        }
+        rule.on_sheet_end(sheet, &mut ctx)
+    }
+
+    // --- INT401: Interrupted by Data ---
+
+    #[test]
+    fn test_value_interrupts_formula_column() {
+        // Column A: F,F,F,V,F,F,F — the V at row 3 interrupts
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "B1+C1"),
+            make_formula_cell(1, 0, "B2+C2"),
+            make_formula_cell(2, 0, "B3+C3"),
+            make_value_cell(3, 0, 42.0),
+            make_formula_cell(4, 0, "B5+C5"),
+            make_formula_cell(5, 0, "B6+C6"),
+            make_formula_cell(6, 0, "B7+C7"),
+        ]);
+        let violations = run_rule(InterruptionKind::Data, &sheet);
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].rule_id, RuleId::Int401);
+    }
+
+    #[test]
+    fn test_value_interrupts_formula_row() {
+        // Row 0: F,F,F,V,F,F,F — the V at col 3 interrupts
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "A2+A3"),
+            make_formula_cell(0, 1, "B2+B3"),
+            make_formula_cell(0, 2, "C2+C3"),
+            make_value_cell(0, 3, 42.0),
+            make_formula_cell(0, 4, "E2+E3"),
+            make_formula_cell(0, 5, "F2+F3"),
+            make_formula_cell(0, 6, "G2+G3"),
+        ]);
+        let violations = run_rule(InterruptionKind::Data, &sheet);
+
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_too_short_sequence() {
+        // Column A: F,F,V,F,F — neither segment is ≥3
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "B1+C1"),
+            make_formula_cell(1, 0, "B2+C2"),
+            make_value_cell(2, 0, 42.0),
+            make_formula_cell(3, 0, "B4+C4"),
+            make_formula_cell(4, 0, "B5+C5"),
+        ]);
+        let violations = run_rule(InterruptionKind::Data, &sheet);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_no_interruption() {
+        // Column A: F,F,F,F — all formulas, no interruption
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "B1+C1"),
+            make_formula_cell(1, 0, "B2+C2"),
+            make_formula_cell(2, 0, "B3+C3"),
+            make_formula_cell(3, 0, "B4+C4"),
+        ]);
+        let violations = run_rule(InterruptionKind::Data, &sheet);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    // --- INT402: Interrupted by Empty ---
+
+    #[test]
+    fn test_empty_interrupts_formula() {
+        // Column A: F,F,F,_,F,F,F — empty at row 3 interrupts
+        // (row 3 simply absent from cell map = empty)
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "B1+C1"),
+            make_formula_cell(1, 0, "B2+C2"),
+            make_formula_cell(2, 0, "B3+C3"),
+            // row 3 is absent → empty
+            make_formula_cell(4, 0, "B5+C5"),
+            make_formula_cell(5, 0, "B6+C6"),
+            make_formula_cell(6, 0, "B7+C7"),
+        ]);
+        let violations = run_rule(InterruptionKind::Empty, &sheet);
+
+        // Empty cell at row 3 is not in the HashMap, so it won't be collected
+        // by on_cell(). The algorithm needs to detect gaps between formula cells.
+        // With the current implementation that only sees populated cells,
+        // gaps are detected if the row/col indices are non-consecutive.
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].rule_id, RuleId::Int402);
+    }
+
+    #[test]
+    fn test_empty_at_end() {
+        // Column A: F,F,F,_ — empty at end is not inside a run
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "B1+C1"),
+            make_formula_cell(1, 0, "B2+C2"),
+            make_formula_cell(2, 0, "B3+C3"),
+        ]);
+        let violations = run_rule(InterruptionKind::Empty, &sheet);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    // --- INT403: Interrupted by Other ---
+
+    #[test]
+    fn test_different_formula_interrupts() {
+        // Column A: same pattern, one different formula
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "B1+C1"),
+            make_formula_cell(1, 0, "B2+C2"),
+            make_formula_cell(2, 0, "B3+C3"),
+            make_formula_cell(3, 0, "SUM(B4:C4)"), // different pattern
+            make_formula_cell(4, 0, "B5+C5"),
+            make_formula_cell(5, 0, "B6+C6"),
+            make_formula_cell(6, 0, "B7+C7"),
+        ]);
+        let violations = run_rule(InterruptionKind::Other, &sheet);
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].rule_id, RuleId::Int403);
+    }
+
+    #[test]
+    fn test_same_pattern_no_violation() {
+        // Column A: all same pattern
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "B1+C1"),
+            make_formula_cell(1, 0, "B2+C2"),
+            make_formula_cell(2, 0, "B3+C3"),
+        ]);
+        let violations = run_rule(InterruptionKind::Other, &sheet);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_normalization() {
+        // Verify that formulas with different absolute refs but same relative structure normalize identically
+        let n1 = InterruptionRule::normalize_formula("B1+C1", 0, 0);
+        let n2 = InterruptionRule::normalize_formula("B2+C2", 1, 0);
+        let n3 = InterruptionRule::normalize_formula("B3+C3", 2, 0);
+        assert_eq!(n1, n2);
+        assert_eq!(n2, n3);
+    }
+
+    // --- Config ---
+
+    #[test]
+    fn test_min_sequence_config() {
+        let mut config = LinterConfig::default();
+        config.global.params.insert(
+            "int_min_formula_sequence".to_string(),
+            toml::Value::Integer(5),
+        );
+        let rule = InterruptionRule::new(InterruptionKind::Data, &config);
+
+        // Column: F×5,V,F×5 — each side has 5 formulas, which meets min=5
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "B1+C1"),
+            make_formula_cell(1, 0, "B2+C2"),
+            make_formula_cell(2, 0, "B3+C3"),
+            make_formula_cell(3, 0, "B4+C4"),
+            make_formula_cell(4, 0, "B5+C5"),
+            make_value_cell(5, 0, 42.0),
+            make_formula_cell(6, 0, "B7+C7"),
+            make_formula_cell(7, 0, "B8+C8"),
+            make_formula_cell(8, 0, "B9+C9"),
+            make_formula_cell(9, 0, "B10+C10"),
+            make_formula_cell(10, 0, "B11+C11"),
+        ]);
+        let mut ctx = LinterContext::default();
+        for cell in sheet.all_cells() {
+            rule.on_cell(&sheet, cell, &mut ctx);
+        }
+        let violations = rule.on_sheet_end(&sheet, &mut ctx);
+
+        // With min=5, each side has 5 formulas → interruption is valid
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_min_sequence_config_below_threshold() {
+        let mut config = LinterConfig::default();
+        config.global.params.insert(
+            "int_min_formula_sequence".to_string(),
+            toml::Value::Integer(5),
+        );
+        let rule = InterruptionRule::new(InterruptionKind::Data, &config);
+
+        // Column: F×3,V,F×3 — each side has only 3, below min=5
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "B1+C1"),
+            make_formula_cell(1, 0, "B2+C2"),
+            make_formula_cell(2, 0, "B3+C3"),
+            make_value_cell(3, 0, 42.0),
+            make_formula_cell(4, 0, "B5+C5"),
+            make_formula_cell(5, 0, "B6+C6"),
+            make_formula_cell(6, 0, "B7+C7"),
+        ]);
+        let mut ctx = LinterContext::default();
+        for cell in sheet.all_cells() {
+            rule.on_cell(&sheet, cell, &mut ctx);
+        }
+        let violations = rule.on_sheet_end(&sheet, &mut ctx);
+
+        // With min=5, neither side has ≥5 → no violation
+        assert_eq!(violations.len(), 0);
     }
 }

--- a/sheetrs/src/rules/int401_interrupted_by_data.rs
+++ b/sheetrs/src/rules/int401_interrupted_by_data.rs
@@ -187,9 +187,14 @@ impl InterruptionRule {
 
     /// Scan a sequence of cells along one axis and find interruptions.
     ///
-    /// The algorithm iterates over actual cells (O(n)), using a HashMap for
-    /// O(1) position lookups. A max-gap limit prevents degenerate behaviour
-    /// on extremely sparse data.
+    /// The algorithm iterates over sorted cells (O(n)), using a HashMap for
+    /// O(1) position lookups. Only a gap of exactly 1 absent position is
+    /// bridged — wider gaps are treated as separate formula contexts.
+    ///
+    /// **Gap policy (gap=1):** A single absent cell between formula cells is
+    /// likely an oversight (missing formula, formatting artifact) and is
+    /// reported as an Empty interruption. Two or more absent cells indicate a
+    /// deliberate section boundary (headers, spacing) and break the run.
     fn find_interruptions(
         cells: &[(u32, CellType)],
         is_column: bool,
@@ -204,11 +209,6 @@ impl InterruptionRule {
 
         // O(1) lookup from position → cell type
         let cell_map: HashMap<u32, &CellType> = cells.iter().map(|(pos, ct)| (*pos, ct)).collect();
-
-        // Maximum gap (absent positions) to bridge between matching formulas.
-        // Beyond this, we consider the run broken. This caps worst-case iteration
-        // for sparse data (e.g. rows 1 and 1_000_000) to O(MAX_GAP) per bridge.
-        const MAX_GAP: u32 = 100;
 
         /// Classify a position from the cell_map (absent = Empty).
         fn classify<'a>(cell_map: &'a HashMap<u32, &'a CellType>, pos: u32) -> &'a CellType {
@@ -236,19 +236,16 @@ impl InterruptionRule {
             while j < cells.len() {
                 let (pos, ct) = &cells[j];
 
-                // If this cell is far beyond run_end, check the gap
-                if *pos > run_end + 1 {
-                    let gap = *pos - run_end - 1;
-                    if gap > MAX_GAP {
-                        // Too sparse — break the run
-                        break;
-                    }
-                    // Record absent positions as Empty interruptions
-                    for gap_pos in (run_end + 1)..*pos {
-                        if !cell_map.contains_key(&gap_pos) {
-                            run_interruptions.push((gap_pos, InterruptionKind::Empty));
-                        }
-                    }
+                // Gap policy: only bridge a gap of exactly 1 absent position.
+                // Wider gaps break the run (new formula context).
+                if *pos > run_end + 2 {
+                    break;
+                }
+
+                // If there is exactly 1 absent position between run_end and
+                // this cell, record it as an Empty interruption.
+                if *pos == run_end + 2 && !cell_map.contains_key(&(run_end + 1)) {
+                    run_interruptions.push((run_end + 1, InterruptionKind::Empty));
                 }
 
                 match ct {
@@ -747,5 +744,65 @@ mod tests {
 
         // With min=5, neither side has ≥5 → no violation
         assert_eq!(violations.len(), 0);
+    }
+
+    // --- Gap policy: gap=1 boundary ---
+
+    #[test]
+    fn test_gap_1_absent_cell_is_bridged() {
+        // Column A: F,F,F,_,F,F,F — gap of 1 absent cell is bridged
+        // (row 3 absent → empty interruption)
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "B1+C1"),
+            make_formula_cell(1, 0, "B2+C2"),
+            make_formula_cell(2, 0, "B3+C3"),
+            // row 3 absent
+            make_formula_cell(4, 0, "B5+C5"),
+            make_formula_cell(5, 0, "B6+C6"),
+            make_formula_cell(6, 0, "B7+C7"),
+        ]);
+        let violations = run_rule(InterruptionKind::Empty, &sheet);
+        assert_eq!(
+            violations.len(),
+            1,
+            "gap=1 should be bridged as interruption"
+        );
+    }
+
+    #[test]
+    fn test_gap_2_absent_cells_breaks_run() {
+        // Column A: F,F,F,_,_,F,F,F — gap of 2 absent cells breaks the run
+        // (rows 3,4 absent → separate contexts → no interruption)
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "B1+C1"),
+            make_formula_cell(1, 0, "B2+C2"),
+            make_formula_cell(2, 0, "B3+C3"),
+            // rows 3,4 absent
+            make_formula_cell(5, 0, "B6+C6"),
+            make_formula_cell(6, 0, "B7+C7"),
+            make_formula_cell(7, 0, "B8+C8"),
+        ]);
+        let violations = run_rule(InterruptionKind::Empty, &sheet);
+        assert_eq!(
+            violations.len(),
+            0,
+            "gap=2 should break the run (separate contexts)"
+        );
+    }
+
+    #[test]
+    fn test_sparse_data_no_false_merge() {
+        // Column A: formulas at rows 0–2 and rows 1000–1002 — far apart
+        // Should be treated as two separate contexts, not one interrupted run
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "B1+C1"),
+            make_formula_cell(1, 0, "B2+C2"),
+            make_formula_cell(2, 0, "B3+C3"),
+            make_formula_cell(1000, 0, "B1001+C1001"),
+            make_formula_cell(1001, 0, "B1002+C1002"),
+            make_formula_cell(1002, 0, "B1003+C1003"),
+        ]);
+        let violations = run_rule(InterruptionKind::Empty, &sheet);
+        assert_eq!(violations.len(), 0, "sparse data should not be merged");
     }
 }

--- a/sheetrs/src/rules/int402_interrupted_by_empty.rs
+++ b/sheetrs/src/rules/int402_interrupted_by_empty.rs
@@ -1,23 +1,8 @@
 //! INT402: Interrupted by Empty detection
 //!
 //! Description: Identifies empty cells that break a consistent formula pattern in a row or column.
+//!
+//! This rule is implemented via the shared [`InterruptionRule`] in
+//! [`int401_interrupted_by_data`](super::int401_interrupted_by_data).
 
-use super::{RuleCategory, WalkerRule};
-use crate::violation::RuleId;
-
-/// Rule that identifies formulas interrupted by empty cells
-pub struct InterruptedByEmptyRule;
-
-impl WalkerRule for InterruptedByEmptyRule {
-    fn id(&self) -> RuleId {
-        RuleId::Int402
-    }
-
-    fn name(&self) -> &str {
-        "Interrupted by Empty"
-    }
-
-    fn category(&self) -> RuleCategory {
-        RuleCategory::Interruptions
-    }
-}
+pub use super::int401_interrupted_by_data::{InterruptionKind, InterruptionRule};

--- a/sheetrs/src/rules/int403_interrupted_by_other.rs
+++ b/sheetrs/src/rules/int403_interrupted_by_other.rs
@@ -1,23 +1,8 @@
 //! INT403: Interrupted by Other detection
 //!
 //! Description: Flags formulas that break a pattern of consistent formulas (e.g., A1=B1+C1, A2=SUM(B2:C2), A3=B3+C3).
+//!
+//! This rule is implemented via the shared [`InterruptionRule`] in
+//! [`int401_interrupted_by_data`](super::int401_interrupted_by_data).
 
-use super::{RuleCategory, WalkerRule};
-use crate::violation::RuleId;
-
-/// Rule that identifies formulas interrupted by a different formula type
-pub struct InterruptedByOtherRule;
-
-impl WalkerRule for InterruptedByOtherRule {
-    fn id(&self) -> RuleId {
-        RuleId::Int403
-    }
-
-    fn name(&self) -> &str {
-        "Interrupted by Other"
-    }
-
-    fn category(&self) -> RuleCategory {
-        RuleCategory::Interruptions
-    }
-}
+pub use super::int401_interrupted_by_data::{InterruptionKind, InterruptionRule};

--- a/sheetrs/src/rules/registry.rs
+++ b/sheetrs/src/rules/registry.rs
@@ -116,7 +116,7 @@ pub fn get_all_rule_metadata(config: &LinterConfig) -> Vec<RuleMetadata> {
 
 /// Create instances of all available walker rules
 pub fn create_all_walker_rules(config: &LinterConfig) -> Vec<Box<dyn WalkerRule>> {
-    vec![
+    let mut rules: Vec<Box<dyn WalkerRule>> = vec![
         // Excel Errors (1xx)
         Box::new(err101_broken_named_ranges::BrokenNamedRangesRule),
         // Unreliable Calculations (2xx)
@@ -125,7 +125,7 @@ pub fn create_all_walker_rules(config: &LinterConfig) -> Vec<Box<dyn WalkerRule>
         // ERR102/ERR103 after CALC202 so on_workbook_end reads circular_cells
         Box::new(err102_error_cells::ErrorCellsRule),
         Box::new(err103_ref_to_error::RefToErrorRule),
-        Box::new(calc203_double_operator::DoubleOperatorRule),
+        Box::new(calc203_double_operator::DoubleOperatorRule::new(config)),
         Box::new(calc204_approximate_lookup::ApproximateLookupRule),
         Box::new(calc205_double_count::DoubleCountRule),
         // Reference Issues (3xx)
@@ -140,12 +140,19 @@ pub fn create_all_walker_rules(config: &LinterConfig) -> Vec<Box<dyn WalkerRule>
         Box::new(ref309_ref_to_empty_cell::RefToEmptyCellRule),
         Box::new(ref310_longer_ref_expected::LongerRefExpectedRule),
         Box::new(ref311_reference_to_pivot::ReferenceToPivotRule),
-        // Formula Interruptions (4xx)
-        Box::new(int401_interrupted_by_data::InterruptedByDataRule),
-        Box::new(int402_interrupted_by_empty::InterruptedByEmptyRule),
-        Box::new(int403_interrupted_by_other::InterruptedByOtherRule),
+    ];
+
+    // Formula Interruptions (4xx) — shared state group to avoid 3× work
+    let [int_data, int_empty, int_other] =
+        int401_interrupted_by_data::InterruptionRule::new_group(config);
+    rules.push(Box::new(int_data));
+    rules.push(Box::new(int_empty));
+    rules.push(Box::new(int_other));
+
+    // Remaining rules
+    rules.extend(vec![
         // Complexity (5xx)
-        Box::new(cpx501_sheet_counts::ExcessiveSheetCountsRule::new(config)),
+        Box::new(cpx501_sheet_counts::ExcessiveSheetCountsRule::new(config)) as Box<dyn WalkerRule>,
         Box::new(cpx502_merged_cells::MergedCellsRule),
         Box::new(
             cpx503_excessive_conditional_formatting::ExcessiveConditionalFormattingRule::new(
@@ -166,7 +173,7 @@ pub fn create_all_walker_rules(config: &LinterConfig) -> Vec<Box<dyn WalkerRule>
             config,
         )),
         Box::new(vul605_legacy_array::LegacyArrayRule),
-        Box::new(vul606_deprecated_func::DeprecatedFuncRule),
+        Box::new(vul606_deprecated_func::DeprecatedFuncRule::new()),
         Box::new(vul607_unprotected::UnprotectedRule),
         // Data Issues (7xx)
         Box::new(dat701_sheet_names::NonDescriptiveSheetNameRule::new(config)),
@@ -188,7 +195,9 @@ pub fn create_all_walker_rules(config: &LinterConfig) -> Vec<Box<dyn WalkerRule>
         Box::new(file1003_date_system_1904::DateSystem1904Rule::new()),
         // VBA Issues (11xx)
         Box::new(vba1101_has_macros::HasMacrosRule),
-    ]
+    ]);
+
+    rules
 }
 
 /// Create enabled walker rules based on configuration
@@ -219,7 +228,7 @@ pub fn clone_walker_rule(rule: &dyn WalkerRule, config: &LinterConfig) -> Box<dy
             Box::new(calc201_hardcoded_values::HardcodedValuesInFormulasRule::new(config))
         }
         RuleId::Calc202 => Box::new(calc202_circular_references::CircularReferenceRule::new()),
-        RuleId::Calc203 => Box::new(calc203_double_operator::DoubleOperatorRule),
+        RuleId::Calc203 => Box::new(calc203_double_operator::DoubleOperatorRule::new(config)),
         RuleId::Calc204 => Box::new(calc204_approximate_lookup::ApproximateLookupRule),
         RuleId::Calc205 => Box::new(calc205_double_count::DoubleCountRule),
         RuleId::Ref301 => Box::new(ref301_unused_named_ranges::UnusedNamedRangesRule::new()),
@@ -233,9 +242,18 @@ pub fn clone_walker_rule(rule: &dyn WalkerRule, config: &LinterConfig) -> Box<dy
         RuleId::Ref309 => Box::new(ref309_ref_to_empty_cell::RefToEmptyCellRule),
         RuleId::Ref310 => Box::new(ref310_longer_ref_expected::LongerRefExpectedRule),
         RuleId::Ref311 => Box::new(ref311_reference_to_pivot::ReferenceToPivotRule),
-        RuleId::Int401 => Box::new(int401_interrupted_by_data::InterruptedByDataRule),
-        RuleId::Int402 => Box::new(int402_interrupted_by_empty::InterruptedByEmptyRule),
-        RuleId::Int403 => Box::new(int403_interrupted_by_other::InterruptedByOtherRule),
+        RuleId::Int401 => Box::new(int401_interrupted_by_data::InterruptionRule::new(
+            int401_interrupted_by_data::InterruptionKind::Data,
+            config,
+        )),
+        RuleId::Int402 => Box::new(int401_interrupted_by_data::InterruptionRule::new(
+            int401_interrupted_by_data::InterruptionKind::Empty,
+            config,
+        )),
+        RuleId::Int403 => Box::new(int401_interrupted_by_data::InterruptionRule::new(
+            int401_interrupted_by_data::InterruptionKind::Other,
+            config,
+        )),
         RuleId::Cpx501 => Box::new(cpx501_sheet_counts::ExcessiveSheetCountsRule::new(config)),
         RuleId::Cpx502 => Box::new(cpx502_merged_cells::MergedCellsRule),
         RuleId::Cpx503 => Box::new(
@@ -256,7 +274,7 @@ pub fn clone_walker_rule(rule: &dyn WalkerRule, config: &LinterConfig) -> Box<dy
             config,
         )),
         RuleId::Vul605 => Box::new(vul605_legacy_array::LegacyArrayRule),
-        RuleId::Vul606 => Box::new(vul606_deprecated_func::DeprecatedFuncRule),
+        RuleId::Vul606 => Box::new(vul606_deprecated_func::DeprecatedFuncRule::new()),
         RuleId::Vul607 => Box::new(vul607_unprotected::UnprotectedRule),
         RuleId::Data701 => Box::new(dat701_sheet_names::NonDescriptiveSheetNameRule::new(config)),
         RuleId::Data702 => Box::new(dat702_numeric_formats::InconsistentNumberFormatRule::new()),

--- a/sheetrs/src/rules/registry.rs
+++ b/sheetrs/src/rules/registry.rs
@@ -218,79 +218,118 @@ pub fn create_enabled_walker_rules(config: &LinterConfig) -> Vec<Box<dyn WalkerR
         .collect()
 }
 
-/// Clone a walker rule for execution (rules need fresh state per lint)
-pub fn clone_walker_rule(rule: &dyn WalkerRule, config: &LinterConfig) -> Box<dyn WalkerRule> {
+/// Clone a walker rule for execution (rules need fresh state per lint).
+///
+/// Returns one or more fresh rule instances. For shared-state groups (INT401–403),
+/// all three instances are returned together to share a single data store.
+pub fn clone_walker_rule(rule: &dyn WalkerRule, config: &LinterConfig) -> Vec<Box<dyn WalkerRule>> {
     match rule.id() {
-        RuleId::Err101 => Box::new(err101_broken_named_ranges::BrokenNamedRangesRule),
-        RuleId::Err102 => Box::new(err102_error_cells::ErrorCellsRule),
-        RuleId::Err103 => Box::new(err103_ref_to_error::RefToErrorRule),
+        RuleId::Err101 => vec![Box::new(err101_broken_named_ranges::BrokenNamedRangesRule)],
+        RuleId::Err102 => vec![Box::new(err102_error_cells::ErrorCellsRule)],
+        RuleId::Err103 => vec![Box::new(err103_ref_to_error::RefToErrorRule)],
         RuleId::Calc201 => {
-            Box::new(calc201_hardcoded_values::HardcodedValuesInFormulasRule::new(config))
+            vec![Box::new(
+                calc201_hardcoded_values::HardcodedValuesInFormulasRule::new(config),
+            )]
         }
-        RuleId::Calc202 => Box::new(calc202_circular_references::CircularReferenceRule::new()),
-        RuleId::Calc203 => Box::new(calc203_double_operator::DoubleOperatorRule::new(config)),
-        RuleId::Calc204 => Box::new(calc204_approximate_lookup::ApproximateLookupRule),
-        RuleId::Calc205 => Box::new(calc205_double_count::DoubleCountRule),
-        RuleId::Ref301 => Box::new(ref301_unused_named_ranges::UnusedNamedRangesRule::new()),
-        RuleId::Ref302 => Box::new(ref302_duplicate_names::DuplicateSheetNamesRule),
-        RuleId::Ref303 => Box::new(ref303_empty_sheets::EmptySheetsRule),
-        RuleId::Ref304 => Box::new(ref304_large_used_range::LargeUsedRangeRule::new()),
-        RuleId::Ref305 => Box::new(ref305_blank_rows_columns::BlankRowsColumnsRule::new()),
-        RuleId::Ref306 => Box::new(ref306_unused_sheets::UnusedSheetsRule),
-        RuleId::Ref307 => Box::new(ref307_whole_column_row_refs::WholeColumnRowRefsRule::new()),
-        RuleId::Ref308 => Box::new(ref308_current_sheet_ref::CurrentSheetRefRule),
-        RuleId::Ref309 => Box::new(ref309_ref_to_empty_cell::RefToEmptyCellRule),
-        RuleId::Ref310 => Box::new(ref310_longer_ref_expected::LongerRefExpectedRule),
-        RuleId::Ref311 => Box::new(ref311_reference_to_pivot::ReferenceToPivotRule),
-        RuleId::Int401 => Box::new(int401_interrupted_by_data::InterruptionRule::new(
-            int401_interrupted_by_data::InterruptionKind::Data,
+        RuleId::Calc202 => vec![Box::new(
+            calc202_circular_references::CircularReferenceRule::new(),
+        )],
+        RuleId::Calc203 => vec![Box::new(calc203_double_operator::DoubleOperatorRule::new(
             config,
-        )),
-        RuleId::Int402 => Box::new(int401_interrupted_by_data::InterruptionRule::new(
-            int401_interrupted_by_data::InterruptionKind::Empty,
-            config,
-        )),
-        RuleId::Int403 => Box::new(int401_interrupted_by_data::InterruptionRule::new(
-            int401_interrupted_by_data::InterruptionKind::Other,
-            config,
-        )),
-        RuleId::Cpx501 => Box::new(cpx501_sheet_counts::ExcessiveSheetCountsRule::new(config)),
-        RuleId::Cpx502 => Box::new(cpx502_merged_cells::MergedCellsRule),
-        RuleId::Cpx503 => Box::new(
+        ))],
+        RuleId::Calc204 => vec![Box::new(calc204_approximate_lookup::ApproximateLookupRule)],
+        RuleId::Calc205 => vec![Box::new(calc205_double_count::DoubleCountRule)],
+        RuleId::Ref301 => vec![Box::new(
+            ref301_unused_named_ranges::UnusedNamedRangesRule::new(),
+        )],
+        RuleId::Ref302 => vec![Box::new(ref302_duplicate_names::DuplicateSheetNamesRule)],
+        RuleId::Ref303 => vec![Box::new(ref303_empty_sheets::EmptySheetsRule)],
+        RuleId::Ref304 => vec![Box::new(ref304_large_used_range::LargeUsedRangeRule::new())],
+        RuleId::Ref305 => vec![Box::new(
+            ref305_blank_rows_columns::BlankRowsColumnsRule::new(),
+        )],
+        RuleId::Ref306 => vec![Box::new(ref306_unused_sheets::UnusedSheetsRule)],
+        RuleId::Ref307 => vec![Box::new(
+            ref307_whole_column_row_refs::WholeColumnRowRefsRule::new(),
+        )],
+        RuleId::Ref308 => vec![Box::new(ref308_current_sheet_ref::CurrentSheetRefRule)],
+        RuleId::Ref309 => vec![Box::new(ref309_ref_to_empty_cell::RefToEmptyCellRule)],
+        RuleId::Ref310 => vec![Box::new(ref310_longer_ref_expected::LongerRefExpectedRule)],
+        RuleId::Ref311 => vec![Box::new(ref311_reference_to_pivot::ReferenceToPivotRule)],
+        // INT401–403: always create the full shared-state group together.
+        // When any one of INT401/402/403 is cloned, emit the whole group.
+        // Duplicates are prevented in lint_workbook by deduplicating rule IDs.
+        RuleId::Int401 | RuleId::Int402 | RuleId::Int403 => {
+            let [data, empty, other] =
+                int401_interrupted_by_data::InterruptionRule::new_group(config);
+            vec![Box::new(data), Box::new(empty), Box::new(other)]
+        }
+        RuleId::Cpx501 => vec![Box::new(
+            cpx501_sheet_counts::ExcessiveSheetCountsRule::new(config),
+        )],
+        RuleId::Cpx502 => vec![Box::new(cpx502_merged_cells::MergedCellsRule)],
+        RuleId::Cpx503 => vec![Box::new(
             cpx503_excessive_conditional_formatting::ExcessiveConditionalFormattingRule::new(
                 config,
             ),
-        ),
-        RuleId::Cpx504 => Box::new(cpx504_deep_if_nesting::DeepIfNestingRule::new(config)),
-        RuleId::Cpx505 => Box::new(cpx505_deep_formula_nesting::DeepFormulaNestingRule),
-        RuleId::Cpx506 => Box::new(cpx506_many_operations::ManyOperationsRule),
-        RuleId::Cpx507 => Box::new(cpx507_multiple_sheet_ref::MultipleSheetRefRule::new(config)),
-        RuleId::Cpx508 => Box::new(cpx508_many_references::ManyReferencesRule),
-        RuleId::Cpx509 => Box::new(cpx509_long_formula::LongFormulaRule),
-        RuleId::Vul601 => Box::new(vul601_duplicate_formulas::DuplicateFormulasRule::new()),
-        RuleId::Vul602 => Box::new(vul602_volatile_functions::VolatileFunctionsRule::new()),
-        RuleId::Vul603 => Box::new(vul603_empty_string_test::EmptyStringTestRule::new()),
-        RuleId::Vul604 => Box::new(vul604_error_prone_functions::ErrorProneFunctionsRule::new(
+        )],
+        RuleId::Cpx504 => vec![Box::new(cpx504_deep_if_nesting::DeepIfNestingRule::new(
             config,
-        )),
-        RuleId::Vul605 => Box::new(vul605_legacy_array::LegacyArrayRule),
-        RuleId::Vul606 => Box::new(vul606_deprecated_func::DeprecatedFuncRule::new()),
-        RuleId::Vul607 => Box::new(vul607_unprotected::UnprotectedRule),
-        RuleId::Data701 => Box::new(dat701_sheet_names::NonDescriptiveSheetNameRule::new(config)),
-        RuleId::Data702 => Box::new(dat702_numeric_formats::InconsistentNumberFormatRule::new()),
-        RuleId::Data703 => Box::new(dat703_date_formats::InconsistentDateFormatRule::new(config)),
-        RuleId::Data704 => Box::new(dat704_long_text::LongTextCellRule::new(config)),
-        RuleId::Data705 => Box::new(dat705_unnecessary_space::UnnecessarySpaceRule),
-        RuleId::Data706 => Box::new(dat706_numeric_text_calc::NumericTextCalcRule),
-        RuleId::Data707 => Box::new(dat707_validation_miss::ValidationMissRule),
-        RuleId::Ext801 => Box::new(ext801_external_workbook::ExternalWorkbooksRule::new()),
-        RuleId::Ext802 => Box::new(ext802_web_urls::WebUrlsRule::new(config)),
-        RuleId::Hid901 => Box::new(hid901_hidden_worksheet::HiddenWorksheetRule),
-        RuleId::Hid902 => Box::new(hid902_hidden_columns_rows::HiddenColumnsRowsRule),
-        RuleId::File1001 => Box::new(file1001_large_file_size::LargeFileSizeRule::new(config)),
-        RuleId::File1002 => Box::new(file1002_old_spreadsheet::OldSpreadsheetRule::new(config)),
-        RuleId::File1003 => Box::new(file1003_date_system_1904::DateSystem1904Rule::new()),
-        RuleId::Vba1101 => Box::new(vba1101_has_macros::HasMacrosRule),
+        ))],
+        RuleId::Cpx505 => vec![Box::new(
+            cpx505_deep_formula_nesting::DeepFormulaNestingRule,
+        )],
+        RuleId::Cpx506 => vec![Box::new(cpx506_many_operations::ManyOperationsRule)],
+        RuleId::Cpx507 => vec![Box::new(
+            cpx507_multiple_sheet_ref::MultipleSheetRefRule::new(config),
+        )],
+        RuleId::Cpx508 => vec![Box::new(cpx508_many_references::ManyReferencesRule)],
+        RuleId::Cpx509 => vec![Box::new(cpx509_long_formula::LongFormulaRule)],
+        RuleId::Vul601 => vec![Box::new(
+            vul601_duplicate_formulas::DuplicateFormulasRule::new(),
+        )],
+        RuleId::Vul602 => vec![Box::new(
+            vul602_volatile_functions::VolatileFunctionsRule::new(),
+        )],
+        RuleId::Vul603 => vec![Box::new(
+            vul603_empty_string_test::EmptyStringTestRule::new(),
+        )],
+        RuleId::Vul604 => vec![Box::new(
+            vul604_error_prone_functions::ErrorProneFunctionsRule::new(config),
+        )],
+        RuleId::Vul605 => vec![Box::new(vul605_legacy_array::LegacyArrayRule)],
+        RuleId::Vul606 => vec![Box::new(vul606_deprecated_func::DeprecatedFuncRule::new())],
+        RuleId::Vul607 => vec![Box::new(vul607_unprotected::UnprotectedRule)],
+        RuleId::Data701 => vec![Box::new(
+            dat701_sheet_names::NonDescriptiveSheetNameRule::new(config),
+        )],
+        RuleId::Data702 => vec![Box::new(
+            dat702_numeric_formats::InconsistentNumberFormatRule::new(),
+        )],
+        RuleId::Data703 => vec![Box::new(
+            dat703_date_formats::InconsistentDateFormatRule::new(config),
+        )],
+        RuleId::Data704 => vec![Box::new(dat704_long_text::LongTextCellRule::new(config))],
+        RuleId::Data705 => vec![Box::new(dat705_unnecessary_space::UnnecessarySpaceRule)],
+        RuleId::Data706 => vec![Box::new(dat706_numeric_text_calc::NumericTextCalcRule)],
+        RuleId::Data707 => vec![Box::new(dat707_validation_miss::ValidationMissRule)],
+        RuleId::Ext801 => vec![Box::new(
+            ext801_external_workbook::ExternalWorkbooksRule::new(),
+        )],
+        RuleId::Ext802 => vec![Box::new(ext802_web_urls::WebUrlsRule::new(config))],
+        RuleId::Hid901 => vec![Box::new(hid901_hidden_worksheet::HiddenWorksheetRule)],
+        RuleId::Hid902 => vec![Box::new(hid902_hidden_columns_rows::HiddenColumnsRowsRule)],
+        RuleId::File1001 => vec![Box::new(file1001_large_file_size::LargeFileSizeRule::new(
+            config,
+        ))],
+        RuleId::File1002 => vec![Box::new(file1002_old_spreadsheet::OldSpreadsheetRule::new(
+            config,
+        ))],
+        RuleId::File1003 => vec![Box::new(
+            file1003_date_system_1904::DateSystem1904Rule::new(),
+        )],
+        RuleId::Vba1101 => vec![Box::new(vba1101_has_macros::HasMacrosRule)],
     }
 }
 

--- a/sheetrs/src/rules/vul606_deprecated_func.rs
+++ b/sheetrs/src/rules/vul606_deprecated_func.rs
@@ -2,11 +2,94 @@
 //!
 //! Description: Identifies functions superseded by modern alternatives (e.g., CONCATENATE vs CONCAT).
 
-use super::{RuleCategory, WalkerRule};
-use crate::violation::RuleId;
+use super::helpers::{bounding_box, find_contiguous_ranges};
+use super::{LinterContext, RuleCategory, WalkerRule};
+use crate::reader::{Cell, Sheet};
+use crate::violation::{
+    CellReference, FormatContext, RuleId, Severity, Violation, ViolationData, ViolationScope,
+};
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
 
-/// Rule that identifies deprecated functions
-pub struct DeprecatedFuncRule;
+/// Deprecated function entries: (deprecated_name, replacement_name).
+const DEPRECATED_FUNCTIONS: &[(&str, &str)] = &[
+    ("CONCATENATE", "CONCAT / TEXTJOIN"), // Excel 2019
+    ("LOOKUP", "XLOOKUP / INDEX+MATCH"),  // Excel 365
+    ("FORECAST", "FORECAST.LINEAR"),      // Excel 2016
+    ("STDEV", "STDEV.S"),                 // Excel 2010
+    ("STDEVP", "STDEV.P"),                // Excel 2010
+    ("VAR", "VAR.S"),                     // Excel 2010
+    ("VARP", "VAR.P"),                    // Excel 2010
+    ("COVAR", "COVARIANCE.P"),            // Excel 2010
+    ("MODE", "MODE.SNGL"),                // Excel 2010
+    ("PERCENTILE", "PERCENTILE.INC"),     // Excel 2010
+    ("PERCENTRANK", "PERCENTRANK.INC"),   // Excel 2010
+    ("QUARTILE", "QUARTILE.INC"),         // Excel 2010
+    ("RANK", "RANK.EQ"),                  // Excel 2010
+    ("CEILING", "CEILING.MATH"),          // Excel 2013
+    ("FLOOR", "FLOOR.MATH"),              // Excel 2013
+];
+
+/// Per-sheet cell collection: sheet_index → Vec<(func_index, row, col)>.
+type SheetCellMap = Mutex<HashMap<u16, Vec<(u8, u32, u32)>>>;
+
+/// Rule that detects usage of deprecated functions.
+pub struct DeprecatedFuncRule {
+    /// Per-sheet collected cells with function index.
+    sheet_cells: SheetCellMap,
+}
+
+impl DeprecatedFuncRule {
+    /// Create a new instance.
+    pub fn new() -> Self {
+        Self {
+            sheet_cells: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for DeprecatedFuncRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Incident data for VUL606.
+#[derive(Debug)]
+pub struct DeprecatedFuncData {
+    /// Index into `DEPRECATED_FUNCTIONS` list.
+    pub func_index: u8,
+    /// Bounding box of violating cells (start_row, start_col, end_row, end_col).
+    pub range: (u32, u32, u32, u32),
+}
+
+impl ViolationData for DeprecatedFuncData {
+    fn format_message(&self, _ctx: &FormatContext<'_>) -> String {
+        let (deprecated, replacement) = DEPRECATED_FUNCTIONS
+            .get(self.func_index as usize)
+            .unwrap_or(&("UNKNOWN", "UNKNOWN"));
+
+        let (sr, sc, er, ec) = self.range;
+        let range_str = if sr == er && sc == ec {
+            CellReference::new(sr, sc).to_string()
+        } else {
+            format!(
+                "{}:{}",
+                CellReference::new(sr, sc),
+                CellReference::new(er, ec)
+            )
+        };
+
+        format!(
+            "Deprecated function {}() found in range: {}. Use {}() instead.",
+            deprecated, range_str, replacement
+        )
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
 
 impl WalkerRule for DeprecatedFuncRule {
     fn id(&self) -> RuleId {
@@ -19,5 +102,176 @@ impl WalkerRule for DeprecatedFuncRule {
 
     fn category(&self) -> RuleCategory {
         RuleCategory::Vulnerability
+    }
+
+    fn on_cell(&self, sheet: &Sheet, cell: &Cell, _ctx: &mut LinterContext) -> Vec<Violation> {
+        if let Some(formula) = cell.as_formula() {
+            let formula_upper = formula.to_uppercase();
+
+            // Pre-computed search patterns: "FUNC(" for each deprecated function.
+            static SEARCH_PATTERNS: LazyLock<Vec<String>> = LazyLock::new(|| {
+                DEPRECATED_FUNCTIONS
+                    .iter()
+                    .map(|(name, _)| format!("{}(", name))
+                    .collect()
+            });
+
+            for (idx, pattern) in SEARCH_PATTERNS.iter().enumerate() {
+                if formula_upper.contains(pattern.as_str()) {
+                    let mut map = self.sheet_cells.lock().unwrap();
+                    map.entry(sheet.sheet_index)
+                        .or_default()
+                        .push((idx as u8, cell.row, cell.col));
+                    break; // Only count each cell once
+                }
+            }
+        }
+        Vec::new()
+    }
+
+    fn on_sheet_end(&self, sheet: &Sheet, _ctx: &mut LinterContext) -> Vec<Violation> {
+        let mut map = self.sheet_cells.lock().unwrap();
+        let cells = match map.remove(&sheet.sheet_index) {
+            Some(c) => c,
+            None => return Vec::new(),
+        };
+
+        let mut violations = Vec::new();
+
+        // Group by function index
+        let mut by_func: HashMap<u8, Vec<(u32, u32)>> = HashMap::new();
+        for (func_idx, row, col) in cells {
+            by_func.entry(func_idx).or_default().push((row, col));
+        }
+
+        for (func_idx, func_cells) in by_func {
+            let ranges = find_contiguous_ranges(&func_cells);
+            for range in ranges {
+                let bbox = bounding_box(&range);
+                violations.push(Violation::with_data(
+                    RuleId::Vul606,
+                    ViolationScope::Sheet(sheet.sheet_index),
+                    DeprecatedFuncData {
+                        func_index: func_idx,
+                        range: bbox,
+                    },
+                    Severity::Info,
+                ));
+            }
+        }
+
+        violations
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reader::workbook::{Cell, CellValue, Sheet};
+    use std::collections::HashMap;
+
+    fn make_formula_cell(row: u32, col: u32, formula: &str) -> Cell {
+        Cell {
+            formula: Some(<Box<str>>::from(formula)),
+            num_fmt: None,
+            row,
+            col,
+            value: CellValue::Empty,
+        }
+    }
+
+    fn make_sheet(cells: Vec<Cell>) -> Sheet {
+        let mut cell_map = HashMap::new();
+        for cell in cells {
+            cell_map.insert((cell.row, cell.col), cell);
+        }
+        Sheet {
+            name: "Sheet1".to_string(),
+            sheet_index: 0,
+            cells: cell_map,
+            ..Default::default()
+        }
+    }
+
+    fn run_rule(rule: &DeprecatedFuncRule, sheet: &Sheet) -> Vec<Violation> {
+        let mut ctx = LinterContext::default();
+        for cell in sheet.all_cells() {
+            rule.on_cell(sheet, cell, &mut ctx);
+        }
+        rule.on_sheet_end(sheet, &mut ctx)
+    }
+
+    #[test]
+    fn test_single_deprecated_function() {
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "CONCATENATE(A2,B2)")]);
+        let rule = DeprecatedFuncRule::new();
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].rule_id, RuleId::Vul606);
+    }
+
+    #[test]
+    fn test_replacement_not_flagged() {
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "CONCAT(A2,B2)")]);
+        let rule = DeprecatedFuncRule::new();
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "concatenate(A2,B2)")]);
+        let rule = DeprecatedFuncRule::new();
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_multiple_deprecated() {
+        let sheet = make_sheet(vec![
+            make_formula_cell(0, 0, "STDEV(A1:A10)"),
+            make_formula_cell(1, 0, "RANK(B1,B1:B10)"),
+        ]);
+        let rule = DeprecatedFuncRule::new();
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 2);
+    }
+
+    #[test]
+    fn test_substring_not_false_positive() {
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "STDEV.S(A1:A10)")]);
+        let rule = DeprecatedFuncRule::new();
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_no_formula() {
+        let mut cell_map = HashMap::new();
+        cell_map.insert(
+            (0, 0),
+            Cell {
+                formula: None,
+                num_fmt: None,
+                row: 0,
+                col: 0,
+                value: CellValue::Number(42.0),
+            },
+        );
+        let sheet = Sheet {
+            name: "Sheet1".to_string(),
+            sheet_index: 0,
+            cells: cell_map,
+            ..Default::default()
+        };
+        let rule = DeprecatedFuncRule::new();
+        let violations = run_rule(&rule, &sheet);
+
+        assert_eq!(violations.len(), 0);
     }
 }

--- a/sheetrs/src/rules/vul606_deprecated_func.rs
+++ b/sheetrs/src/rules/vul606_deprecated_func.rs
@@ -116,12 +116,24 @@ impl WalkerRule for DeprecatedFuncRule {
                     .collect()
             });
 
+            let formula_bytes = formula_upper.as_bytes();
             let mut map = self.sheet_cells.lock().unwrap();
             for (idx, pattern) in SEARCH_PATTERNS.iter().enumerate() {
-                if formula_upper.contains(pattern.as_str()) {
-                    map.entry(sheet.sheet_index)
-                        .or_default()
-                        .push((idx as u8, cell.row, cell.col));
+                // Find all occurrences and check word boundary before each
+                let pat_bytes = pattern.as_bytes();
+                let mut search_from = 0;
+                while let Some(rel_pos) = formula_upper[search_from..].find(pattern.as_str()) {
+                    let abs_pos = search_from + rel_pos;
+                    // Only match if NOT preceded by a letter (rejects VLOOKUP→LOOKUP, etc.)
+                    let is_word_start =
+                        abs_pos == 0 || !formula_bytes[abs_pos - 1].is_ascii_alphabetic();
+                    if is_word_start {
+                        map.entry(sheet.sheet_index)
+                            .or_default()
+                            .push((idx as u8, cell.row, cell.col));
+                        break; // Found a genuine match for this pattern in this cell
+                    }
+                    search_from = abs_pos + pat_bytes.len();
                 }
             }
         }
@@ -272,5 +284,62 @@ mod tests {
         let violations = run_rule(&rule, &sheet);
 
         assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_vlookup_not_false_positive() {
+        // VLOOKUP contains LOOKUP but should NOT trigger the deprecated LOOKUP rule
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "VLOOKUP(A1,B:C,2,FALSE)")]);
+        let rule = DeprecatedFuncRule::new();
+        let violations = run_rule(&rule, &sheet);
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_hlookup_not_false_positive() {
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "HLOOKUP(A1,1:3,2,FALSE)")]);
+        let rule = DeprecatedFuncRule::new();
+        let violations = run_rule(&rule, &sheet);
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_xlookup_not_false_positive() {
+        // XLOOKUP is the recommended replacement for LOOKUP — must NOT be flagged
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "XLOOKUP(A1,B1:B10,C1:C10)")]);
+        let rule = DeprecatedFuncRule::new();
+        let violations = run_rule(&rule, &sheet);
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_bare_lookup_still_flagged() {
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "LOOKUP(A1,B1:B10,C1:C10)")]);
+        let rule = DeprecatedFuncRule::new();
+        let violations = run_rule(&rule, &sheet);
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_covar_not_flagged_as_var() {
+        // COVAR contains VAR but should only flag COVAR, not VAR
+        let sheet = make_sheet(vec![make_formula_cell(0, 0, "COVAR(A1:A10,B1:B10)")]);
+        let rule = DeprecatedFuncRule::new();
+        let violations = run_rule(&rule, &sheet);
+        // Should flag COVAR only, not also VAR
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_two_deprecated_in_one_cell() {
+        // A single cell with two different deprecated functions should produce two violations
+        let sheet = make_sheet(vec![make_formula_cell(
+            0,
+            0,
+            "CONCATENATE(STDEV(A1:A10),B1)",
+        )]);
+        let rule = DeprecatedFuncRule::new();
+        let violations = run_rule(&rule, &sheet);
+        assert_eq!(violations.len(), 2);
     }
 }

--- a/sheetrs/src/rules/vul606_deprecated_func.rs
+++ b/sheetrs/src/rules/vul606_deprecated_func.rs
@@ -116,13 +116,12 @@ impl WalkerRule for DeprecatedFuncRule {
                     .collect()
             });
 
+            let mut map = self.sheet_cells.lock().unwrap();
             for (idx, pattern) in SEARCH_PATTERNS.iter().enumerate() {
                 if formula_upper.contains(pattern.as_str()) {
-                    let mut map = self.sheet_cells.lock().unwrap();
                     map.entry(sheet.sheet_index)
                         .or_default()
                         .push((idx as u8, cell.row, cell.col));
-                    break; // Only count each cell once
                 }
             }
         }

--- a/sheetrs/src/violation.rs
+++ b/sheetrs/src/violation.rs
@@ -472,7 +472,7 @@ impl CellReference {
     }
 
     /// Convert column number to letter (0 -> A, 1 -> B, etc.)
-    fn col_to_letter(mut col: u32) -> String {
+    pub fn col_to_letter(mut col: u32) -> String {
         let mut result = String::new();
         loop {
             result.insert(0, (b'A' + (col % 26) as u8) as char);


### PR DESCRIPTION
## Summary

Implement five must-be audit rules from the Kano analysis: **CALC203**, **INT401–403**, and **VUL606**.

## Rules Implemented

| Rule | Name | Description |
|------|------|-------------|
| CALC203 | Double Operator | Detects redundant double operators in formulas (e.g., `A1++B1`) |
| INT401 | Interrupted by Data | Detects value cells interrupting formula sequences |
| INT402 | Interrupted by Empty | Detects empty cells interrupting formula sequences |
| INT403 | Interrupted by Other | Detects different-formula cells interrupting formula sequences |
| VUL606 | Deprecated Functions | Detects usage of deprecated Excel functions (e.g., CONCATENATE, LOOKUP) |

## Architecture

### INT401–403: Shared-State Group Pattern
- Three rule instances share a single `Arc<Mutex<...>>` data store via `new_group()`
- Only the collector instance processes `on_cell()` / `on_sheet_end()`, emitting violations for all three rule IDs
- `clone_walker_rule()` returns `Vec<Box<dyn WalkerRule>>` to support group creation; `lint_workbook` deduplicates by rule ID

### Formula Normalization
- Formulas are normalized to R1C1-style relative offsets for pattern comparison
- Regex skips false matches on function names (LOG10) and sheet qualifiers (SHEET1!) via context checks
- Column letters limited to `{1,3}` (valid Excel range A–XFD)

### Gap Policy (gap=1)
- 1 absent cell between formulas: bridged as Empty interruption (likely oversight)
- 2+ absent cells: run breaks (separate formula contexts)
- Strictly O(n) — no range iteration

### VUL606: Word-Boundary Matching
- Checks character before match to prevent false positives (VLOOKUP/HLOOKUP/XLOOKUP ≠ LOOKUP)
- Reports all deprecated functions per cell (no early break)

### CALC203: Smart Operator Detection
- Distinguishes redundant doubles (`A1++B1`) from valid binary+unary patterns (`A1*-B1`)
- Configurable `calc203_allow_double_negative` to permit `--` coercion

## Bug Fixes (Devin Review)
- **VUL606 false positives**: VLOOKUP/HLOOKUP/XLOOKUP no longer falsely flagged as deprecated LOOKUP
- **INT 3× duplication**: `clone_walker_rule` now uses `new_group()` instead of standalone instances
- **INT sparse data perf**: Replaced O(range) algorithm with O(n) cell-based iteration + gap=1 policy
- **VUL606 under-reporting**: Removed early `break` — all deprecated functions per cell are reported

## Tests
- 177 tests passing (14 INT, 12 VUL606, 6 CALC203 + existing suite)
- Gap boundary tests: gap=1 bridged, gap=2 breaks, sparse data no merge
- VUL606 boundary tests: VLOOKUP/HLOOKUP/XLOOKUP/COVAR false positive prevention

## Documentation
- `docs/coding-patterns.md`: Shared-State Groups, Formula Normalization, Gap Policy, Configuration Parameters